### PR TITLE
added the type virtual function to avoid dynamic cast

### DIFF
--- a/corelib/include/rtabmap/core/Odometry.h
+++ b/corelib/include/rtabmap/core/Odometry.h
@@ -57,6 +57,8 @@ public:
 	Transform process(SensorData & data, OdometryInfo * info = 0);
 	Transform process(SensorData & data, const Transform & guess, OdometryInfo * info = 0);
 	virtual void reset(const Transform & initialPose = Transform::getIdentity());
+	virtual bool isF2F(){return false;}
+	virtual bool isF2M(){return false;}
 
 	//getters
 	const Transform & getPose() const {return _pose;}

--- a/corelib/include/rtabmap/core/OdometryF2F.h
+++ b/corelib/include/rtabmap/core/OdometryF2F.h
@@ -45,6 +45,8 @@ public:
 
 	const Signature & getRefFrame() const {return refFrame_;}
 
+	bool isF2F(){return true;};
+
 private:
 	virtual Transform computeTransform(SensorData & image, const Transform & guess = Transform(), OdometryInfo * info = 0);
 

--- a/corelib/include/rtabmap/core/OdometryF2M.h
+++ b/corelib/include/rtabmap/core/OdometryF2M.h
@@ -48,6 +48,8 @@ public:
 	const Signature & getMap() const {return *map_;}
 	const Signature & getLastFrame() const {return *lastFrame_;}
 
+	bool isF2M(){return true;}
+
 private:
 	virtual Transform computeTransform(SensorData & data, const Transform & guess = Transform(), OdometryInfo * info = 0);
 


### PR DESCRIPTION
Use virtual function to quickly determine what type of class is, so to avoid using dynamic cast which may slower run-time performance