### PR TITLE
include list in FlannIndex.h

### DIFF
--- a/corelib/include/rtabmap/core/FlannIndex.h
+++ b/corelib/include/rtabmap/core/FlannIndex.h
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CORELIB_SRC_FLANNINDEX_H_
 
 #include "rtabmap/core/RtabmapExp.h" // DLL export/import defines
-
+#include <list>
 #include <opencv2/opencv.hpp>
 
 namespace rtabmap {


### PR DESCRIPTION
Had a bug while building about list not in std, fixed by just add it into the header file.

In file included from /home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:28:0:
/home/zeng/essential/rtabmap/corelib/src/../include/rtabmap/core/FlannIndex.h:109:2: error: ‘list’ in namespace ‘std’ does not name a type
  std::list<int> removedIndexes_;
  ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp: In member function ‘void rtabmap::FlannIndex::release()’:
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:77:2: error: ‘removedIndexes_’ was not declared in this scope
  removedIndexes_.clear();
  ^
In file included from /home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:29:0:
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp: In member function ‘unsigned int rtabmap::FlannIndex::addPoints(const cv::Mat&)’:
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:372:25: error: ‘removedIndexes_’ was not declared in this scope
   UASSERT(removedPts == removedIndexes_.size());
                         ^
/home/zeng/essential/rtabmap/utilite/include/rtabmap/utilite/ULogger.h:64:33: note: in definition of macro ‘UASSERT’
 #define UASSERT(condition) if(!(condition)) ULogger::write(ULogger::kFatal, __FILE__, __LINE__, __FUNCTION__, "Condition (%s) not met!", #condition)
                                 ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:374:7: error: ‘list’ is not a member of ‘std’
   for(std::list<int>::iterator iter=removedIndexes_.begin(); iter!=removedIndexes_.end(); ++iter)
       ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:374:17: error: expected primary-expression before ‘int’
   for(std::list<int>::iterator iter=removedIndexes_.begin(); iter!=removedIndexes_.end(); ++iter)
                 ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:374:17: error: expected ‘;’ before ‘int’
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:374:62: error: ‘iter’ was not declared in this scope
   for(std::list<int>::iterator iter=removedIndexes_.begin(); iter!=removedIndexes_.end(); ++iter)
                                                              ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:374:68: error: ‘removedIndexes_’ was not declared in this scope
   for(std::list<int>::iterator iter=removedIndexes_.begin(); iter!=removedIndexes_.end(); ++iter)
                                                                    ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:378:3: error: ‘removedIndexes_’ was not declared in this scope
   removedIndexes_.clear();
   ^
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp: In member function ‘void rtabmap::FlannIndex::removePoint(unsigned int)’:
/home/zeng/essential/rtabmap/corelib/src/FlannIndex.cpp:418:2: error: ‘removedIndexes_’ was not declared in this scope
  removedIndexes_.push_back(index);
