### PR TITLE
Fix bug with ostream operator<< for Transform

### DIFF
--- a/corelib/src/Transform.cpp
+++ b/corelib/src/Transform.cpp
@@ -282,9 +282,9 @@ std::ostream& operator<<(std::ostream& os, const Transform& s)
 	{
 		for(int j = 0; j < 4; ++j)
 		{
-			std::cout << std::left << std::setw(12) << s.data()[i*4 + j];
+			os << std::left << std::setw(12) << s.data()[i*4 + j];
 		}
-		std::cout << std::endl;
+		os << std::endl;
 	}
 	return os;
 }


### PR DESCRIPTION
I had problem with << operator on Transform - it writes to std::cout instead of given ostream os:
```
std::ostream& operator<<(std::ostream& os, const Transform& s)
{
        for(int i = 0; i < 3; ++i)
        {
                for(int j = 0; j < 4; ++j)
                {
                        std::cout << std::left << std::setw(12) << s.data()[i*4 + j];
                }
                std::cout << std::endl;
        }
        return os;
}
```
This commit just replaces std::cout with os:
```
std::ostream& operator<<(std::ostream& os, const Transform& s)
{
        for(int i = 0; i < 3; ++i)
        {
                for(int j = 0; j < 4; ++j)
                {
                        os << std::left << std::setw(12) << s.data()[i*4 + j];
                }
                os << std::endl;
        }
        return os;
}
```
