### PR TITLE
Fix missing space in ostream operator <<  for Transform

### DIFF
--- a/corelib/src/Transform.cpp
+++ b/corelib/src/Transform.cpp
@@ -282,7 +282,7 @@ std::ostream& operator<<(std::ostream& os, const Transform& s)
 	{
 		for(int j = 0; j < 4; ++j)
 		{
-			os << std::left << std::setw(12) << s.data()[i*4 + j];
+			os << std::left << std::setw(12) << s.data()[i*4 + j] << " ";
 		}
 		os << std::endl;
 	}


### PR DESCRIPTION
Another problem with ostream operator <<  for Transform - missing space between numbers:
```
1           1.38778e-17 -8.32667e-17-4.44089e-16
4.16334e-17 1           5.55112e-17 -6.59195e-17
-2.77556e-173.33067e-16 1           5.55112e-17 
```
Commit just adds space after each number.