### PR TITLE
change for zed sdk 2.0

### DIFF
--- a/corelib/include/rtabmap/core/CameraStereo.h
+++ b/corelib/include/rtabmap/core/CameraStereo.h
@@ -42,10 +42,7 @@ class Camera;
 
 namespace sl
 {
-namespace zed
-{
 class Camera;
-}
 }
 
 namespace rtabmap
@@ -148,7 +145,7 @@ protected:
 
 private:
 #ifdef RTABMAP_ZED
-	sl::zed::Camera * zed_;
+	sl::Camera * zed_;
 	StereoCameraModel stereoModel_;
 	CameraVideo::Source src_;
 	int usbDevice_;


### PR DESCRIPTION
ZED SDK version is 2.0 now.(https://www.stereolabs.com/developers/)
So I want to use 2.0. 
It seems works well for me (Ubuntu 16.04).


There may be better solution in following 2 implementations. Anyway it works.
-slMat3cvMat  in line 939
-for loop in line 1016
