### PR TITLE
KAZE - fix loading custom feature params

### DIFF
--- a/corelib/src/Features2d.cpp
+++ b/corelib/src/Features2d.cpp
@@ -1496,6 +1496,8 @@ KAZE::~KAZE()
 
 void KAZE::parseParameters(const ParametersMap & parameters)
 {
+	Feature2D::parseParameters(parameters);
+	
 	Parameters::parse(parameters, Parameters::kKAZEExtended(), extended_);
 	Parameters::parse(parameters, Parameters::kKAZEUpright(), upright_);
 	Parameters::parse(parameters, Parameters::kKAZEThreshold(), threshold_);


### PR DESCRIPTION
KAZE feature detector does not load custom feature params (min/max depth, ROI, etc).