### PR TITLE
Update CameraThread.cpp

### DIFF
--- a/corelib/src/CameraThread.cpp
+++ b/corelib/src/CameraThread.cpp
@@ -255,7 +255,9 @@ void CameraThread::postUpdate(SensorData * dataPtr, CameraInfo * info) const
 					data.cameraModels()[0].fy(),
 					float(data.imageRaw().cols) - data.cameraModels()[0].cx(),
 					data.cameraModels()[0].cy(),
-					data.cameraModels()[0].localTransform());
+					data.cameraModels()[0].localTransform(),
+					data.cameraModels()[0].Tx(),
+					data.cameraModels()[0].imageSize());
 			data.setCameraModel(tmpModel);
 		}
 		if(!data.depthRaw().empty())


### PR DESCRIPTION
When Mirroring option is checked, a depth calibration cannot be done because of the new mirrored CameraModel named tmpModel have its imageSize set to cv::Size(0, 0) so the method named isValidForReprojection() (which used in CalibrationDialog.cpp to check that the camera model is valid to do the calibration method) always returns false