### PR TITLE
Proper closing of name space with in the #RTABMAP_H_

### DIFF
--- a/corelib/include/rtabmap/core/Rtabmap.h
+++ b/corelib/include/rtabmap/core/Rtabmap.h
@@ -293,6 +293,5 @@ private:
 
 };
 
-#endif /* RTABMAP_H_ */
-
 } // namespace rtabmap
+#endif /* RTABMAP_H_ */


### PR DESCRIPTION
Proper closing of name space with in the #RTABMAP_H_. Multiple includes of "Rtabmap.h" with in the component causing the compilation problem.