### PR TITLE
Add missing -DDISABLE_VTK to WITH_QT=OFF build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,9 @@ IF(WITH_QT)
         ENDIF()
         ADD_DEFINITIONS(-DQT_NO_KEYWORDS) # To avoid conflicts with boost signals/foreach and Qt macros
     ENDIF(QT4_FOUND OR Qt5_FOUND)
-ENDIF(WITH_QT)
+ELSE()
+    ADD_DEFINITIONS(-DDISABLE_VTK)
+ENDIF()
 
 IF(WITH_TORCH)
     FIND_PACKAGE(Torch QUIET)


### PR DESCRIPTION
Otherwise complains about missing VTK headers like this
```
rtabmap/corelib/src/Parameters.cpp:45:10: fatal error: 'vtkVersion.h' file not found
#include <vtkVersion.h>
         ^~~~~~~~~~~~~~
1 error generated.
```