### PR TITLE
List dependencies only once

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rtabmap</name>
   <version>0.20.17</version>
   <description>RTAB-Map's standalone library. RTAB-Map is a RGB-D SLAM approach with real-time constraints.</description>
@@ -11,32 +11,22 @@
   <url type="repository">https://github.com/introlab/rtabmap</url>
 
   <buildtool_depend>cmake</buildtool_depend>
-  
-  <build_depend>qt_gui_cpp</build_depend> <!-- libqt4-dev or libqt5-dev -->
-  <build_depend>libpcl-all-dev</build_depend> <!--  include libvtk-qt -->
-  <build_depend>libsqlite3-dev</build_depend>
-  <build_depend>zlib</build_depend>
-  <build_depend>libfreenect-dev</build_depend>
-  <build_depend>libopenni-dev</build_depend>
-  <!--<build_depend>libopenni2-dev</build_depend> --> <!-- not available on Jessie -->
-  <build_depend>cv_bridge</build_depend>
-  <!-- libproj-dev needed due to error in vtk6 (kinetic)-->
+
   <build_depend>proj</build_depend>
-  <build_depend>octomap</build_depend>
-  <build_depend>libg2o</build_depend>
-  
-  <run_depend>qt_gui_cpp</run_depend>
-  <run_depend>libpcl-all-dev</run_depend> <!--  include libvtk-qt -->
-  <run_depend>libsqlite3-dev</run_depend>
-  <run_depend>zlib</run_depend>
-  <run_depend>libfreenect-dev</run_depend>
-  <run_depend>libopenni-dev</run_depend>
-  <!-- <run_depend>libopenni2-dev</run_depend> -->
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>octomap</run_depend>
-  <run_depend>libg2o</run_depend>
+  <depend>cv_bridge</depend>
+  <depend>libfreenect-dev</depend>
+  <depend>libg2o</depend>
+  <depend>libopenni-dev</depend>
+  <!-- <depend>libopenni2-dev</depend> --> <!-- not available on Jessie -->
+  <depend>libpcl-all-dev</depend> <!--  include libvtk-qt -->
+  <depend>libpointmatcher</depend>
+  <!-- <depend>libproj-dev</depend> needed due to error in vtk6 (kinetic)-->
+  <depend>libsqlite3-dev</depend>
+  <depend>octomap</depend>
+  <depend>qt_gui_cpp</depend> <!-- libqt4-dev or libqt5-dev -->
+  <depend>zlib</depend>
 
   <export>
-	 <build_type>cmake</build_type>
+	  <build_type>cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
I kept the comments. 

Seems like `libopenni2-dev` is available on all platforms these days? 