### PR TITLE
Correct Jacobian for XYFactor

### DIFF
--- a/corelib/src/optimizer/gtsam/XYFactor.h
+++ b/corelib/src/optimizer/gtsam/XYFactor.h
@@ -45,8 +45,8 @@ public:
 
     // note that use boost optional like a pointer
     // only calculate jacobian matrix when non-null pointer exists
-    if (H) *H = (gtsam::Matrix23() << 1.0, 0.0, 0.0,
-                                      0.0, 1.0, 0.0).finished();
+    if (H) *H = (gtsam::Matrix23() << p.rotation().c(),-p.rotation().s(), 0.0,
+                                      p.rotation().s(), p.rotation().c(), 0.0).finished();
 
     // return error vector
     return (gtsam::Vector2() << p.x() - mx_, p.y() - my_).finished();


### PR DESCRIPTION
The Jacobian for the XYFactor was incorrect. This happens to be the example for the Unary factor on gtsam documentation, where the correct Jacobian is given:
https://gtsam.org/tutorials/intro.html#:~:text=In%20GTSAM%2C%20you%20can%20create,%7D%20%3D%20f%20(%20q%20)%20where