### PR TITLE
fixes for texture mesh export for pcl > 1.13.0

### DIFF
--- a/guilib/include/rtabmap/gui/ExportCloudsDialog.h
+++ b/guilib/include/rtabmap/gui/ExportCloudsDialog.h
@@ -153,6 +153,10 @@ private:
 	GainCompensator * _compensator;
 	const DBDriver * _dbDriver;
 	bool _scansHaveRGB;
+
+    bool saveOBJFile(const QString &path, pcl::TextureMesh::Ptr &mesh) const;
+    bool saveOBJFile(const QString &path, pcl::PolygonMesh &mesh) const;
+
 };
 
 }


### PR DESCRIPTION
PCL 1.13.0 introduced tex_coord_indices in pcl::TextureMesh. Omitting to fill the new vector causes a segmentation fault. The pull request fixes this issue and makes exporting textured meshes possible again.