### PR TITLE
add depthai gftt detector

### DIFF
--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -63,7 +63,7 @@ public:
 	void setLaserDotBrightness(float dotProjectormA = 0.0f);
 	void setFloodLightBrightness(float floodLightmA = 200.0f);
 	void setDetectFeatures(int detectFeatures = 0);
-	void setGFTTDetector(bool useHarrisDetector, double minDistance = 7.0f);
+	void setGFTTDetector(bool useHarrisDetector, double minDistance = 7.0f, int numTargetFeatures = 1000);
 
 	virtual bool init(const std::string & calibrationFolder = ".", const std::string & cameraName = "");
 	virtual bool isCalibrated() const;
@@ -89,6 +89,7 @@ private:
 	int detectFeatures_;
 	bool useHarrisDetector_;
 	double minDistance_;
+	int numTargetFeatures_;
 	std::shared_ptr<dai::Device> device_;
 	std::shared_ptr<dai::DataOutputQueue> leftQueue_;
 	std::shared_ptr<dai::DataOutputQueue> rightOrDepthQueue_;

--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -62,6 +62,7 @@ public:
 	void publishInterIMU(bool enabled);
 	void setLaserDotBrightness(float dotProjectormA = 0.0f);
 	void setFloodLightBrightness(float floodLightmA = 200.0f);
+	void setDetectFeatures(int detectFeatures = 1);
 
 	virtual bool init(const std::string & calibrationFolder = ".", const std::string & cameraName = "");
 	virtual bool isCalibrated() const;
@@ -84,9 +85,11 @@ private:
 	bool publishInterIMU_;
 	float dotProjectormA_;
 	float floodLightmA_;
+	int detectFeatures_;
 	std::shared_ptr<dai::Device> device_;
 	std::shared_ptr<dai::DataOutputQueue> leftQueue_;
 	std::shared_ptr<dai::DataOutputQueue> rightOrDepthQueue_;
+	std::shared_ptr<dai::DataOutputQueue> featuresQueue_;
 	std::map<double, cv::Vec3f> accBuffer_;
 	std::map<double, cv::Vec3f> gyroBuffer_;
 	UMutex imuMutex_;

--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -62,7 +62,8 @@ public:
 	void publishInterIMU(bool enabled);
 	void setLaserDotBrightness(float dotProjectormA = 0.0f);
 	void setFloodLightBrightness(float floodLightmA = 200.0f);
-	void setDetectFeatures(int detectFeatures = 1);
+	void setDetectFeatures(int detectFeatures = 0);
+	void setGFTTDetector(bool useHarrisDetector, double minDistance = 7.0f);
 
 	virtual bool init(const std::string & calibrationFolder = ".", const std::string & cameraName = "");
 	virtual bool isCalibrated() const;
@@ -86,6 +87,8 @@ private:
 	float dotProjectormA_;
 	float floodLightmA_;
 	int detectFeatures_;
+	bool useHarrisDetector_;
+	double minDistance_;
 	std::shared_ptr<dai::Device> device_;
 	std::shared_ptr<dai::DataOutputQueue> leftQueue_;
 	std::shared_ptr<dai::DataOutputQueue> rightOrDepthQueue_;

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -64,7 +64,8 @@ CameraDepthAI::CameraDepthAI(
 	floodLightmA_(200.0),
 	detectFeatures_(0),
 	useHarrisDetector_(false),
-	minDistance_(7.0)
+	minDistance_(7.0),
+	numTargetFeatures_(1000)
 #endif
 {
 #ifdef RTABMAP_DEPTHAI
@@ -158,11 +159,12 @@ void CameraDepthAI::setDetectFeatures(int detectFeatures)
 #endif
 }
 
-void CameraDepthAI::setGFTTDetector(bool useHarrisDetector, double minDistance)
+void CameraDepthAI::setGFTTDetector(bool useHarrisDetector, double minDistance, int numTargetFeatures)
 {
 #ifdef RTABMAP_DEPTHAI
 	useHarrisDetector_ = useHarrisDetector;
 	minDistance_ = minDistance;
+	numTargetFeatures_ = numTargetFeatures;
 #else
 	UERROR("CameraDepthAI: RTAB-Map is not built with depthai-core support!");
 #endif
@@ -298,8 +300,10 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 
 	if(detectFeatures_ == 1)
 	{
+		gfttDetector->setHardwareResources(1, 2);
 		gfttDetector->initialConfig.setCornerDetector(
 			useHarrisDetector_?dai::FeatureTrackerConfig::CornerDetector::Type::HARRIS:dai::FeatureTrackerConfig::CornerDetector::Type::SHI_THOMASI);
+		gfttDetector->initialConfig.setNumTargetFeatures(numTargetFeatures_);
 		gfttDetector->initialConfig.setMotionEstimator(false);
 		auto cfg = gfttDetector->initialConfig.get();
 		cfg.featureMaintainer.minimumDistanceBetweenFeatures = minDistance_ * minDistance_;

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -6342,7 +6342,7 @@ Camera * PreferencesDialog::createCamera(
 		((CameraDepthAI*)camera)->setDetectFeatures(_ui->comboBox_depthai_detect_features->currentIndex());
 		if(_ui->comboBox_depthai_detect_features->currentIndex() == 1)
 		{
-			((CameraDepthAI*)camera)->setGFTTDetector(_ui->checkBox_GFTT_useHarrisDetector->isChecked(), _ui->doubleSpinBox_GFTT_minDistance->value());
+			((CameraDepthAI*)camera)->setGFTTDetector(_ui->checkBox_GFTT_useHarrisDetector->isChecked(), _ui->doubleSpinBox_GFTT_minDistance->value(), _ui->reextract_maxFeatures->value());
 		}
 	}
 	else if(driver == kSrcUsbDevice)

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -810,6 +810,7 @@ PreferencesDialog::PreferencesDialog(QWidget * parent) :
 	connect(_ui->checkBox_depthai_imu_firmware_update, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_laser_dot_brightness, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_floodlight_brightness, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->comboBox_depthai_detect_features, SIGNAL(currentIndexChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 
 	connect(_ui->checkbox_rgbd_colorOnly, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->spinBox_source_imageDecimation, SIGNAL(valueChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
@@ -2067,6 +2068,7 @@ void PreferencesDialog::resetSettings(QGroupBox * groupBox)
 		_ui->checkBox_depthai_imu_firmware_update->setChecked(false);
 		_ui->doubleSpinBox_depthai_laser_dot_brightness->setValue(0.0);
 		_ui->doubleSpinBox_depthai_floodlight_brightness->setValue(200.0);
+		_ui->comboBox_depthai_detect_features->setCurrentIndex(0);
 
 		_ui->checkBox_cameraImages_configForEachFrame->setChecked(false);
 		_ui->checkBox_cameraImages_timestamps->setChecked(false);
@@ -2554,6 +2556,7 @@ void PreferencesDialog::readCameraSettings(const QString & filePath)
 	_ui->checkBox_depthai_imu_firmware_update->setChecked(settings.value("imu_firmware_update", _ui->checkBox_depthai_imu_firmware_update->isChecked()).toBool());
 	_ui->doubleSpinBox_depthai_laser_dot_brightness->setValue(settings.value("laser_dot_brightness", _ui->doubleSpinBox_depthai_laser_dot_brightness->value()).toDouble());
 	_ui->doubleSpinBox_depthai_floodlight_brightness->setValue(settings.value("floodlight_brightness", _ui->doubleSpinBox_depthai_floodlight_brightness->value()).toDouble());
+	_ui->comboBox_depthai_detect_features->setCurrentIndex(settings.value("detect_features", _ui->comboBox_depthai_detect_features->currentIndex()).toInt());
 	settings.endGroup(); // DepthAI
 
 	settings.beginGroup("Images");
@@ -3084,6 +3087,7 @@ void PreferencesDialog::writeCameraSettings(const QString & filePath) const
 	settings.setValue("imu_firmware_update",   _ui->checkBox_depthai_imu_firmware_update->isChecked());
 	settings.setValue("laser_dot_brightness",  _ui->doubleSpinBox_depthai_laser_dot_brightness->value());
 	settings.setValue("floodlight_brightness", _ui->doubleSpinBox_depthai_floodlight_brightness->value());
+	settings.setValue("detect_features",       _ui->comboBox_depthai_detect_features->currentIndex());
 	settings.endGroup(); // DepthAI
 
 	settings.beginGroup("Images");
@@ -6335,6 +6339,11 @@ Camera * PreferencesDialog::createCamera(
 		((CameraDepthAI*)camera)->publishInterIMU(_ui->checkbox_publishInterIMU->isChecked());
 		((CameraDepthAI*)camera)->setLaserDotBrightness(_ui->doubleSpinBox_depthai_laser_dot_brightness->value());
 		((CameraDepthAI*)camera)->setFloodLightBrightness(_ui->doubleSpinBox_depthai_floodlight_brightness->value());
+		((CameraDepthAI*)camera)->setDetectFeatures(_ui->comboBox_depthai_detect_features->currentIndex());
+		if(_ui->comboBox_depthai_detect_features->currentIndex() == 1)
+		{
+			((CameraDepthAI*)camera)->setGFTTDetector(_ui->checkBox_GFTT_useHarrisDetector->isChecked(), _ui->doubleSpinBox_GFTT_minDistance->value());
+		}
 	}
 	else if(driver == kSrcUsbDevice)
 	{

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -6024,6 +6024,39 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
+                                  <item row="8" column="0">
+                                   <widget class="QComboBox" name="comboBox_depthai_detect_features">
+                                    <property name="currentIndex">
+                                     <number>0</number>
+                                    </property>
+                                    <property name="sizeAdjustPolicy">
+                                     <enum>QComboBox::AdjustToContents</enum>
+                                    </property>
+                                    <item>
+                                     <property name="text">
+                                      <string>None</string>
+                                     </property>
+                                    </item>
+                                    <item>
+                                     <property name="text">
+                                      <string>GFTT</string>
+                                     </property>
+                                    </item>
+                                   </widget>
+                                  </item>
+                                  <item row="8" column="1">
+                                   <widget class="QLabel" name="label_679">
+                                    <property name="text">
+                                     <string>On-device feature detector.</string>
+                                    </property>
+                                    <property name="wordWrap">
+                                     <bool>true</bool>
+                                    </property>
+                                    <property name="textInteractionFlags">
+                                     <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                                    </property>
+                                   </widget>
+                                  </item>
                                  </layout>
                                 </widget>
                                </item>


### PR DESCRIPTION
Hi, I added on-device GFTT feature according to your note. I'll try to add SuperPoint later. So later for `detectFeatures_`, 0 is None, 1 is GFTT, 2 is SuperPoint. Or change it to enum afterwards.

There are some differences between DepthAI and OpenCV in the implementation of GFTT. I'm trying to reuse parameters set in other panels, which might be a little awkward. Maybe you have a better way. I tried many parameters, mainly to increase the number of features. DepthAI first uses CornerDetector to detect corner points, and then uses FeatureMaintainer to filter out some. So when `numTargetFeatures` is set to 320 by default, it may only return more than 200 points in the end. This can make rtabmap less stable. Regarding the actual `numMaxFeatures`, the [docs](https://docs.luxonis.com/projects/api/en/latest/references/cpp/#_CPPv4N3dai23RawFeatureTrackerConfig14CornerDetector14numMaxFeaturesE) say:
> Hard limit for the maximum number of features that can be detected. 0 means auto, will be set to the maximum value based on memory constraints.

So I increased the number of memory slices to 2. This does seem to increase the number of features. Now when `numTargetFeatures` is set to 1000, more than 500 points can be obtained in most scenes. On-board detection takes about 7ms. But don't increase the number of shaves to 2, it will cause the detection time to increase to more than 30ms. I have no idea why. MotionEstimator is disabled. But we can also try to use  on-device optical flow later. Although there doesn't seem to be an interface for setting optical flow data. Return only tracked points may improve stability, or reduce host computation.