### PR TITLE
Remove dependency on qt_gui_cpp.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
   <!-- <depend>libproj-dev</depend> needed due to error in vtk6 (kinetic)-->
   <depend>libsqlite3-dev</depend>
   <depend>octomap</depend>
-  <depend>qt_gui_cpp</depend> <!-- libqt4-dev or libqt5-dev -->
+  <depend>qtbase5-dev</depend>
   <depend>zlib</depend>
 
   <export>


### PR DESCRIPTION
There is no dependency in this package on qt_gui_cpp. Instead, just use a dependency on qtbase5-dev