### PR TITLE
OAK-D PoE Update

### DIFF
--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -49,7 +49,7 @@ public:
 
 public:
 	CameraDepthAI(
-			const std::string & deviceSerial = "",
+			const std::string & mxidOrName = "",
 			int resolution = 1, // 0=720p, 1=800p, 2=400p
 			float imageRate=0.0f,
 			const Transform & localTransform = Transform::getIdentity());
@@ -79,7 +79,7 @@ private:
 	StereoCameraModel stereoModel_;
 	cv::Size targetSize_;
 	Transform imuLocalTransform_;
-	std::string deviceSerial_;
+	std::string mxidOrName_;
 	bool outputDepth_;
 	int depthConfidence_;
 	int resolution_;

--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -104,6 +104,8 @@ private:
 	std::map<double, cv::Vec3f> accBuffer_;
 	std::map<double, cv::Vec3f> gyroBuffer_;
 	UMutex imuMutex_;
+
+	static std::string ProtocolToStr(XLinkProtocol_t val);
 #endif
 };
 

--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -104,8 +104,6 @@ private:
 	std::map<double, cv::Vec3f> accBuffer_;
 	std::map<double, cv::Vec3f> gyroBuffer_;
 	UMutex imuMutex_;
-
-	static std::string ProtocolToStr(XLinkProtocol_t val);
 #endif
 };
 

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -327,7 +327,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	monoRight->out.link(stereo->right);
 
 	// Using VideoEncoder on PoE devices, Subpixel is not supported
-	if(ProtocolToStr(deviceToUse.protocol) == "X_LINK_TCP_IP")
+	if(deviceToUse.protocol == X_LINK_TCP_IP)
 	{
 		auto leftEnc  = p.create<dai::node::VideoEncoder>();
 		auto depthOrRightEnc  = p.create<dai::node::VideoEncoder>();
@@ -560,7 +560,7 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 		rectifRightOrDepth = rightOrDepthQueue_->get<dai::ImgFrame>();
 
 	double stamp = std::chrono::duration<double>(rectifL->getTimestampDevice(dai::CameraExposureOffset::MIDDLE).time_since_epoch()).count();
-	if(ProtocolToStr(device_->getDeviceInfo().protocol) == "X_LINK_TCP_IP")
+	if(device_->getDeviceInfo().protocol == X_LINK_TCP_IP)
 	{
 		left = cv::imdecode(rectifL->getData(), cv::IMREAD_GRAYSCALE);
 		depthOrRight = cv::imdecode(rectifRightOrDepth->getData(), cv::IMREAD_GRAYSCALE);
@@ -702,31 +702,5 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 #endif
 	return data;
 }
-
-#ifdef RTABMAP_DEPTHAI
-std::string CameraDepthAI::ProtocolToStr(XLinkProtocol_t val)
-{
-	switch (val)
-	{
-	case X_LINK_USB_VSC:
-		return "X_LINK_USB_VSC";
-	case X_LINK_USB_CDC:
-		return "X_LINK_USB_CDC";
-	case X_LINK_PCIE:
-		return "X_LINK_PCIE";
-	case X_LINK_IPC:
-		return "X_LINK_IPC";
-	case X_LINK_TCP_IP:
-		return "X_LINK_TCP_IP";
-	case X_LINK_NMB_OF_PROTOCOLS:
-		return "X_LINK_NMB_OF_PROTOCOLS";
-	case X_LINK_ANY_PROTOCOL:
-		return "X_LINK_ANY_PROTOCOL";
-	default:
-		return "INVALID_ENUM_VALUE";
-		break;
-	}
-}
-#endif
 
 } // namespace rtabmap

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -428,8 +428,15 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		else if(eeprom.boardName == "DM9098")
 		{
 			imuLocalTransform_ = Transform(
-				 0,  1,  0,  0.0754,
-				 1,  0,  0,  0.0026,
+				 0,  1,  0,  0.075445,
+				 1,  0,  0,  0.00079,
+				 0,  0, -1, -0.007);
+		}
+		else if(eeprom.boardName == "NG9097")
+		{
+			imuLocalTransform_ = Transform(
+				 0,  1,  0,  0.0775,
+				 1,  0,  0,  0.020265,
 				 0,  0, -1, -0.007);
 		}
 		else

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -703,9 +703,9 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 	return data;
 }
 
+#ifdef RTABMAP_DEPTHAI
 std::string CameraDepthAI::ProtocolToStr(XLinkProtocol_t val)
 {
-#ifdef RTABMAP_DEPTHAI
 	switch (val)
 	{
 	case X_LINK_USB_VSC:
@@ -726,8 +726,7 @@ std::string CameraDepthAI::ProtocolToStr(XLinkProtocol_t val)
 		return "INVALID_ENUM_VALUE";
 		break;
 	}
-#endif
-	return "";
 }
+#endif
 
 } // namespace rtabmap

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -426,7 +426,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	double fy = new_camera_matrix.at<double>(1, 1);
 	double cx = new_camera_matrix.at<double>(0, 2);
 	double cy = new_camera_matrix.at<double>(1, 2);
-	double baseline = calibHandler.getBaselineDistance(dai::CameraBoardSocket::CAM_C, dai::CameraBoardSocket::CAM_B, false)/100.0;
+	double baseline = calibHandler.getBaselineDistance()/100.0;
 	UINFO("left: fx=%f fy=%f cx=%f cy=%f baseline=%f", fx, fy, cx, cy, baseline);
 	stereoModel_ = StereoCameraModel(device_->getDeviceName(), fx, fy, cx, cy, baseline, this->getLocalTransform(), targetSize_);
 


### PR DESCRIPTION
I have received OAK-D Pro W PoE. Its IMU local transform is easy to determine, it has the same orientation as the USB model, but with a different offset. What is more troublesome is the communication bandwidth. I couldn't get enough camera frame rate and IMU frame rate with the previous configuration. The official documentation says a lot about this. I'll have to see what tuning needs to be done.
In addition, the previous USB models equipped with BMI270 also have [IMU frame rate problems](https://github.com/luxonis/depthai-ros/issues/145). Certain algorithms may be affected.