### PR TITLE
MSCKF_VIO Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,8 +777,8 @@ IF(NOT MSVC)
         message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support. Please use a different C++ compiler if you want to use Qt6.")
       ENDIF()
     ENDIF()
-    IF((NOT (${CMAKE_CXX_STANDARD} STREQUAL "17")) AND ((NOT WITH_MSCKF_VIO OR NOT msckf_vio_FOUND) AND (loam_velodyne_FOUND OR floam_FOUND OR PCL_VERSION VERSION_GREATER "1.9.1" OR TORCH_FOUND OR G2O_FOUND OR CCCoreLib_FOUND OR Open3D_FOUND)))
-     #LOAM, PCL>=1.10, latest g2o and CCCoreLib require c++14, but MSCKF_VIO requires c++11
+    IF((NOT (${CMAKE_CXX_STANDARD} STREQUAL "17")) AND (msckf_vio_FOUND OR loam_velodyne_FOUND OR floam_FOUND OR PCL_VERSION VERSION_GREATER "1.9.1" OR TORCH_FOUND OR G2O_FOUND OR CCCoreLib_FOUND OR Open3D_FOUND))
+     #MSCKF_VIO, LOAM, PCL>=1.10, latest g2o and CCCoreLib require c++14
      include(CheckCXXCompilerFlag)
       CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
       IF(COMPILER_SUPPORTS_CXX14)
@@ -801,7 +801,6 @@ IF(NOT MSVC)
            ORB_SLAM_FOUND OR
            okvis_FOUND OR
            open_chisel_FOUND OR
-           msckf_vio_FOUND OR
            vins_FOUND OR
            ov_msckf_FOUND OR
            libpointmatcher_FOUND))


### PR DESCRIPTION
Now msckf_vio is ready to use. Tested with OAK cameras. You can refer to [this patch](https://gist.github.com/borongyuan/90f10aa6969ebccdba2b19ce0cfa77ea) or [my fork](https://github.com/borongyuan/msckf_vio) for changes. I made some changes to the initial frame. Now the body frame and IMU frame have the same reference frame, avoiding the inconvenience of https://github.com/KumarRobotics/msckf_vio/issues/39#issuecomment-398562078. After initialization, the body frame is located at the origin of the world frame, and its orientation is aligned with gravity. This is consistent with the initialization of the odometry of RTAB-Map. Some of the previous hardcoded parameters seem to be for the euroc dataset. After modification it should be suitable for other hardwares.