### PR TITLE
CMake: Add compatibility for yaml-cpp 0.8.0.

### DIFF
--- a/tools/EurocDataset/CMakeLists.txt
+++ b/tools/EurocDataset/CMakeLists.txt
@@ -1,27 +1,31 @@
 
 FIND_PACKAGE(yaml-cpp QUIET)
 
-IF(NOT yaml-cpp_FOUND)
+IF(yaml-cpp_FOUND)
+  # yaml-cpp 0.8.0 uses the wrong target in YAML_CPP_LIBRARIES.
+  IF(yaml-cpp_VERSION VERSION_EQUAL "0.8.0")
+    SET(YAML_CPP_LIBRARIES yaml-cpp::yaml-cpp)
+  ENDIF()
+ELSE()
    find_package(PkgConfig QUIET)
    IF(PKG_CONFIG_FOUND)
       pkg_check_modules(yaml_cpp QUIET yaml-cpp)
 	  IF(yaml_cpp_FOUND)
          SET(YAML_CPP_LIBRARIES ${yaml_cpp_LIBRARIES})
-         SET(YAML_CPP_INCLUDE_DIRS ${yaml_cpp_INCLUDEDIR})
+         SET(YAML_CPP_INCLUDE_DIR ${yaml_cpp_INCLUDEDIR})
          SET(yaml-cpp_FOUND ${yaml_cpp_FOUND})
 	  ENDIF(yaml_cpp_FOUND)
    ENDIF(PKG_CONFIG_FOUND)
-ENDIF(NOT yaml-cpp_FOUND)
+ENDIF(yaml-cpp_FOUND)
 
 IF(yaml-cpp_FOUND)
 
 SET(INCLUDE_DIRS
-    ${YAML_CPP_INCLUDE_DIRS}
+    ${YAML_CPP_INCLUDE_DIR}
 )
 
 SET(LIBRARIES
 	${YAML_CPP_LIBRARIES}
-	yaml-cpp
 )
 
 INCLUDE_DIRECTORIES(${INCLUDE_DIRS} yaml-cpp)


### PR DESCRIPTION
When packaging yaml-cpp 0.8.0 on vcpkg, there were build issues with rtabmap.

Notably, the debug build fails due to `LIBRARIES` having `yaml-cpp` hardcoded, while yaml-cpp has a debug postfix. This, in combination with 0.8.0 renaming the target to `yaml-cpp::yaml-cpp` means that `yaml-cpp` is treated as a literal library name.

This PR updates the find logic to address these issues:
- For the include directories, the variable name used upstream is [`YAML_CPP_INCLUDE_DIR`](https://github.com/jbeder/yaml-cpp/blob/f7320141120f720aecc4c32be25586e7da9eb978/yaml-cpp-config.cmake.in#L10).
- The target name in 0.8.0 changed to `yaml-cpp::yaml-cpp`, but the variable `YAML_CPP_LIBRARIES` was not updated. This issue has already been reported upstream, but when this specific version of yaml-cpp is found, just overwrite the `YAML_CPP_LIBRARIES` with the correct target name.