### PR TITLE
Update OAK stereo config and IMU rate

### DIFF
--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -324,6 +324,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	auto config = stereo->initialConfig.get();
 	config.censusTransform.kernelSize = dai::StereoDepthConfig::CensusTransform::KernelSize::KERNEL_7x9;
 	config.censusTransform.kernelMask = 0X2AA00AA805540155;
+	config.postProcessing.brightnessFilter.maxBrightness = 255;
 	stereo->initialConfig.set(config);
 
 	// Link plugins CAM -> STEREO -> XLINK

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -320,7 +320,11 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	stereo->initialConfig.setConfidenceThreshold(depthConfidence_);
 	stereo->initialConfig.setLeftRightCheck(true);
 	stereo->initialConfig.setLeftRightCheckThreshold(5);
-	stereo->initialConfig.setMedianFilter(dai::MedianFilter::KERNEL_5x5);
+	stereo->initialConfig.setMedianFilter(dai::MedianFilter::KERNEL_7x7);
+	auto config = stereo->initialConfig.get();
+	config.censusTransform.kernelSize = dai::StereoDepthConfig::CensusTransform::KernelSize::KERNEL_7x9;
+	config.censusTransform.kernelMask = 0X2AA00AA805540155;
+	stereo->initialConfig.set(config);
 
 	// Link plugins CAM -> STEREO -> XLINK
 	monoLeft->out.link(stereo->left);
@@ -345,7 +349,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	{
 		stereo->setSubpixel(true);
 		stereo->setSubpixelFractionalBits(4);
-		auto config = stereo->initialConfig.get();
+		config = stereo->initialConfig.get();
 		config.costMatching.disparityWidth = dai::StereoDepthConfig::CostMatching::DisparityWidth::DISPARITY_64;
 		config.costMatching.enableCompanding = true;
 		stereo->initialConfig.set(config);
@@ -358,8 +362,8 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 
 	if(imuPublished_)
 	{
-		// enable ACCELEROMETER_RAW and GYROSCOPE_RAW at 200 hz rate
-		imu->enableIMUSensor({dai::IMUSensor::ACCELEROMETER_RAW, dai::IMUSensor::GYROSCOPE_RAW}, 200);
+		// enable ACCELEROMETER_RAW and GYROSCOPE_RAW at 100 hz rate
+		imu->enableIMUSensor({dai::IMUSensor::ACCELEROMETER_RAW, dai::IMUSensor::GYROSCOPE_RAW}, 100);
 		// above this threshold packets will be sent in batch of X, if the host is not blocked and USB bandwidth is available
 		imu->setBatchReportThreshold(1);
 		// maximum number of IMU packets in a batch, if it's reached device will block sending until host can receive it


### PR DESCRIPTION
The kernel size of census transform is set to AUTO by default. Looks like CT-7x7 is used at 800p. I found that CT-7x9 gives better depth quality for both 800p and 400p. Don't know why it is not used as default.
IMU rate is set to 100 Hz as none of the devices with BMI270 can reach 200 Hz. PoE models can go up to around 120 Hz. It works well when using msckf_vio. Feature noise is best reduced to 0.02 to avoid drift.
Msckf_vio may not be the most accurate VIO, but it is certainly robust. I often encounter drift issues when using OpenVINS, and I am still looking for the cause.