### PR TITLE
fix for Undefined symbols for architecture x86_64: "Nabo::NearestNeighbourSearch<double... when link to libpointmatcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,9 @@ IF(WITH_POINTMATCHER)
     find_package(libpointmatcher QUIET)
     IF(libpointmatcher_FOUND)
        MESSAGE(STATUS "Found libpointmatcher: ${libpointmatcher_INCLUDE_DIRS}")
+       # Find libnabo:
+       find_package(libnabo REQUIRED PATHS ${LIBNABO_INSTALL_DIR})
+       message(STATUS "libnabo found, version ${libnabo_VERSION} (Config mode)")
     ENDIF(libpointmatcher_FOUND)
 ENDIF(WITH_POINTMATCHER)
 

--- a/corelib/src/CMakeLists.txt
+++ b/corelib/src/CMakeLists.txt
@@ -457,6 +457,7 @@ IF(libpointmatcher_FOUND)
 	SET(LIBRARIES
 		${LIBRARIES}
 		${libpointmatcher_LIBRARIES}
+		libnabo::nabo
 	)
 ENDIF(libpointmatcher_FOUND)
 


### PR DESCRIPTION
When link to libpointmatcher master(https://github.com/ethz-asl/libpointmatcher) with libnabo master (https://github.com/ethz-asl/libnabo) compiler failed:  

Undefined symbols for architecture x86_64:
"Nabo::NearestNeighbourSearch<double, Eigen::Matrix<double, -1, -1, 0, -1, -1> >::create(Eigen::Matrix<double, -1, -1, 0, -1, -1> const&, int, Nabo::NearestNeighbourSearch<double, Eigen::Matrix<double, -1, -1, 0, -1, -1> >::SearchType, unsigned int, ...

related to https://github.com/ethz-asl/libpointmatcher/issues/514 
and I employ a fix from https://github.com/ethz-asl/libpointmatcher/pull/513 to fix this error.