### PR TITLE
OAK bug fixes and improvements

### DIFF
--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -56,8 +56,8 @@ public:
 	virtual ~CameraDepthAI();
 
 	void setOutputDepth(bool enabled, int confidence = 200);
+	void setUseSpecTranslation(bool useSpecTranslation);
 	void setAlphaScaling(float alphaScaling = 0.0f);
-	void setIMUFirmwareUpdate(bool enabled);
 	void setIMUPublished(bool published);
 	void publishInterIMU(bool enabled);
 	void setLaserDotBrightness(float dotProjectormA = 0.0f);
@@ -83,8 +83,8 @@ private:
 	bool outputDepth_;
 	int depthConfidence_;
 	int resolution_;
+	bool useSpecTranslation_;
 	float alphaScaling_;
-	bool imuFirmwareUpdate_;
 	bool imuPublished_;
 	bool publishInterIMU_;
 	float dotProjectormA_;

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -805,9 +805,9 @@ PreferencesDialog::PreferencesDialog(QWidget * parent) :
 	connect(_ui->comboBox_depthai_resolution, SIGNAL(currentIndexChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->checkBox_depthai_depth, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->spinBox_depthai_confidence, SIGNAL(valueChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->checkBox_depthai_use_spec_translation, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_alpha_scaling, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->checkBox_depthai_imu_published, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
-	connect(_ui->checkBox_depthai_imu_firmware_update, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_laser_dot_brightness, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_floodlight_brightness, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->comboBox_depthai_detect_features, SIGNAL(currentIndexChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
@@ -2111,9 +2111,9 @@ void PreferencesDialog::resetSettings(QGroupBox * groupBox)
 		_ui->comboBox_depthai_resolution->setCurrentIndex(1);
 		_ui->checkBox_depthai_depth->setChecked(false);
 		_ui->spinBox_depthai_confidence->setValue(200);
+		_ui->checkBox_depthai_use_spec_translation->setChecked(false);
 		_ui->doubleSpinBox_depthai_alpha_scaling->setValue(0.0);
 		_ui->checkBox_depthai_imu_published->setChecked(true);
-		_ui->checkBox_depthai_imu_firmware_update->setChecked(false);
 		_ui->doubleSpinBox_depthai_laser_dot_brightness->setValue(0.0);
 		_ui->doubleSpinBox_depthai_floodlight_brightness->setValue(200.0);
 		_ui->comboBox_depthai_detect_features->setCurrentIndex(0);
@@ -2601,9 +2601,9 @@ void PreferencesDialog::readCameraSettings(const QString & filePath)
 	_ui->comboBox_depthai_resolution->setCurrentIndex(settings.value("resolution", _ui->comboBox_depthai_resolution->currentIndex()).toInt());
 	_ui->checkBox_depthai_depth->setChecked(settings.value("depth", _ui->checkBox_depthai_depth->isChecked()).toBool());
 	_ui->spinBox_depthai_confidence->setValue(settings.value("confidence", _ui->spinBox_depthai_confidence->value()).toInt());
+	_ui->checkBox_depthai_use_spec_translation->setChecked(settings.value("use_spec_translation", _ui->checkBox_depthai_use_spec_translation->isChecked()).toBool());
 	_ui->doubleSpinBox_depthai_alpha_scaling->setValue(settings.value("alpha_scaling", _ui->doubleSpinBox_depthai_alpha_scaling->value()).toDouble());
 	_ui->checkBox_depthai_imu_published->setChecked(settings.value("imu_published", _ui->checkBox_depthai_imu_published->isChecked()).toBool());
-	_ui->checkBox_depthai_imu_firmware_update->setChecked(settings.value("imu_firmware_update", _ui->checkBox_depthai_imu_firmware_update->isChecked()).toBool());
 	_ui->doubleSpinBox_depthai_laser_dot_brightness->setValue(settings.value("laser_dot_brightness", _ui->doubleSpinBox_depthai_laser_dot_brightness->value()).toDouble());
 	_ui->doubleSpinBox_depthai_floodlight_brightness->setValue(settings.value("floodlight_brightness", _ui->doubleSpinBox_depthai_floodlight_brightness->value()).toDouble());
 	_ui->comboBox_depthai_detect_features->setCurrentIndex(settings.value("detect_features", _ui->comboBox_depthai_detect_features->currentIndex()).toInt());
@@ -3131,12 +3131,12 @@ void PreferencesDialog::writeCameraSettings(const QString & filePath) const
 	settings.endGroup(); // MyntEye
 
 	settings.beginGroup("DepthAI");
-	settings.setValue("resolution",    _ui->comboBox_depthai_resolution->currentIndex());
-	settings.setValue("depth",         _ui->checkBox_depthai_depth->isChecked());
-	settings.setValue("confidence",    _ui->spinBox_depthai_confidence->value());
-	settings.setValue("alpha_scaling", _ui->doubleSpinBox_depthai_alpha_scaling->value());
-	settings.setValue("imu_published", _ui->checkBox_depthai_imu_published->isChecked());
-	settings.setValue("imu_firmware_update",   _ui->checkBox_depthai_imu_firmware_update->isChecked());
+	settings.setValue("resolution",            _ui->comboBox_depthai_resolution->currentIndex());
+	settings.setValue("depth",                 _ui->checkBox_depthai_depth->isChecked());
+	settings.setValue("confidence",            _ui->spinBox_depthai_confidence->value());
+	settings.setValue("use_spec_translation",  _ui->checkBox_depthai_use_spec_translation->isChecked());
+	settings.setValue("alpha_scaling",         _ui->doubleSpinBox_depthai_alpha_scaling->value());
+	settings.setValue("imu_published",         _ui->checkBox_depthai_imu_published->isChecked());
 	settings.setValue("laser_dot_brightness",  _ui->doubleSpinBox_depthai_laser_dot_brightness->value());
 	settings.setValue("floodlight_brightness", _ui->doubleSpinBox_depthai_floodlight_brightness->value());
 	settings.setValue("detect_features",       _ui->comboBox_depthai_detect_features->currentIndex());
@@ -6404,8 +6404,8 @@ Camera * PreferencesDialog::createCamera(
 			this->getGeneralInputRate(),
 			this->getSourceLocalTransform());
 		((CameraDepthAI*)camera)->setOutputDepth(_ui->checkBox_depthai_depth->isChecked(), _ui->spinBox_depthai_confidence->value());
+		((CameraDepthAI*)camera)->setUseSpecTranslation(_ui->checkBox_depthai_use_spec_translation->isChecked());
 		((CameraDepthAI*)camera)->setAlphaScaling(_ui->doubleSpinBox_depthai_alpha_scaling->value());
-		((CameraDepthAI*)camera)->setIMUFirmwareUpdate(_ui->checkBox_depthai_imu_firmware_update->isChecked());
 		((CameraDepthAI*)camera)->setIMUPublished(_ui->checkBox_depthai_imu_published->isChecked());
 		((CameraDepthAI*)camera)->publishInterIMU(_ui->checkbox_publishInterIMU->isChecked());
 		((CameraDepthAI*)camera)->setLaserDotBrightness(_ui->doubleSpinBox_depthai_laser_dot_brightness->value());

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -5882,7 +5882,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </item>
                                    </widget>
                                   </item>
-                                  <item row="3" column="0">
+                                  <item row="4" column="0">
                                    <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_alpha_scaling">
                                     <property name="minimum">
                                      <double>-1.000000000000000</double>
@@ -5924,7 +5924,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="4" column="0">
+                                  <item row="5" column="0">
                                    <widget class="QCheckBox" name="checkBox_depthai_imu_published">
                                     <property name="text">
                                      <string/>
@@ -5957,10 +5957,10 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="5" column="1">
+                                  <item row="3" column="1">
                                    <widget class="QLabel" name="label_646">
                                     <property name="text">
-                                     <string>IMU firmware update</string>
+                                     <string>Use the translation information from the board design data (not the calibration data).</string>
                                     </property>
                                     <property name="wordWrap">
                                      <bool>true</bool>
@@ -5990,7 +5990,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="3" column="1">
+                                  <item row="4" column="1">
                                    <widget class="QLabel" name="label_678">
                                     <property name="text">
                                      <string>Free scaling parameter between 0 (when all the pixels in the undistorted image are valid) and 1 (when all the source image pixels are retained in the undistorted image). On some high distortion lenses, and/or due to rectification (image rotated) invalid areas may appear even with alpha=0, in these cases alpha &lt; 0.0 helps removing invalid areas. If alpha is set to -1, old rectification policy is used.</string>
@@ -6016,7 +6016,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="4" column="1">
+                                  <item row="5" column="1">
                                    <widget class="QLabel" name="label_650">
                                     <property name="text">
                                      <string>IMU published</string>
@@ -6029,8 +6029,8 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="5" column="0">
-                                   <widget class="QCheckBox" name="checkBox_depthai_imu_firmware_update">
+                                  <item row="3" column="0">
+                                   <widget class="QCheckBox" name="checkBox_depthai_use_spec_translation">
                                     <property name="text">
                                      <string/>
                                     </property>


### PR DESCRIPTION
Fix distortion correction problem of small FOV devices.
I have been testing with wide FOV devices before. When I tried OAK-D S2 today I found that it didn't work at all. I checked [the doc](https://docs.luxonis.com/projects/api/en/latest/references/cpp/#_CPPv4N3dai21StereoDepthProperties26useHomographyRectificationE) and found that the default configuration does not perform distortion correction on small FOV devices. I can't understand why they do this. We need to force distortion correction on all devices.

Remove deprecated IMU firmware update API.
enableFirmwareUpdate() is deprecated since https://github.com/luxonis/depthai-core/commit/12b198a67f9c7a56747666679f00763c35cf64e3. I don't feel the need to deal with firmware updates here. Most devices don't need to be updated. Or the user should have updated it in advance.

Add useSpecTranslation option.
We have had some discussions about this parameter before (https://github.com/luxonis/depthai-core/issues/358 & https://github.com/luxonis/depthai-core/issues/847). But most users are probably unaware of this potential problem. Although they insist that the translation information from the board design data will have better accuracy in most cases. But I actually have a development version of OAK that is not for sale. They changed the color camera's FOV, global shutter, and IMU model according to my requirements. The camera modules are all glued on by hand, so I don't think there's any manufacturing precision. I also noticed that the RAE's lens looks a bit skewed as well, although I haven't tested it yet. So let’s use the calibration data by default. It guarantees at least a lower bound of accuracy and meets most users' expectations.
From my experience, this parameter may have an impact on the accuracy and robustness of stereo VIO. If you read [OpenVINS paper](https://pgeneva.com/downloads/papers/Geneva2020ICRA.pdf), you will find that mono mode often performs better than stereo mode. The accuracy of the baseline and different feature representations have a certain impact.

Reduce depth image noise and simplify calculation for compressed transport.
Depth images have fewer textures than mono images and therefore have higher compression rates when using mjpeg compression. So we can set the quality to the highest level without consuming too much bandwidth. The advantage of this is that it can reduce the noise generated near the sharp edges during depth map compression. Especially at the edges where depth values are missing. These noises are mainly caused by DCT during jpeg encoding. This doesn't completely eliminate the noise, but it's better than before. It should be better to use lossless jpeg mode, but currently OpenCV is unable to decode it. We will see if there are other decoding methods later, such as using ffmpeg or nvjpeg.
[cv::divide()](https://docs.opencv.org/4.x/d2/de8/group__core__array.html#ga6db555d30115642fedae0cda05604874) is supposed to be more efficient than the forEach method. It can handle division by 0.