### PR TITLE
start outputting data after static initialization

### DIFF
--- a/corelib/include/rtabmap/core/Parameters.h
+++ b/corelib/include/rtabmap/core/Parameters.h
@@ -641,9 +641,9 @@ class RTABMAP_CORE_EXPORT Parameters
     RTABMAP_PARAM(OdomOpenVINS, AccelerometerRandomWalk,   double, 0.001,  "[m/s^3/sqrt(Hz)] (accel bias diffusion)");
     RTABMAP_PARAM(OdomOpenVINS, GyroscopeNoiseDensity,     double, 0.001,  "[rad/s/sqrt(Hz)] (gyro \"white noise\")");
     RTABMAP_PARAM(OdomOpenVINS, GyroscopeRandomWalk,       double, 0.0001, "[rad/s^2/sqrt(Hz)] (gyro bias diffusion)");
-    RTABMAP_PARAM(OdomOpenVINS, UpMSCKFSigmaPx,            double, 2.0,    "Pixel noise for MSCKF features");
+    RTABMAP_PARAM(OdomOpenVINS, UpMSCKFSigmaPx,            double, 1.0,    "Pixel noise for MSCKF features");
     RTABMAP_PARAM(OdomOpenVINS, UpMSCKFChi2Multiplier,     double, 1.0,    "Chi2 multiplier for MSCKF features");
-    RTABMAP_PARAM(OdomOpenVINS, UpSLAMSigmaPx,             double, 2.0,    "Pixel noise for SLAM features");
+    RTABMAP_PARAM(OdomOpenVINS, UpSLAMSigmaPx,             double, 1.0,    "Pixel noise for SLAM features");
     RTABMAP_PARAM(OdomOpenVINS, UpSLAMChi2Multiplier,      double, 1.0,    "Chi2 multiplier for SLAM features");
 
     // Odometry Open3D

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -19580,7 +19580,7 @@ If set to false, classic RTAB-Map loop closure detection is done using only imag
                                  <double>0.100000000000000</double>
                                 </property>
                                 <property name="value">
-                                 <double>2.000000000000000</double>
+                                 <double>1.000000000000000</double>
                                 </property>
                                </widget>
                               </item>
@@ -19638,7 +19638,7 @@ If set to false, classic RTAB-Map loop closure detection is done using only imag
                                  <double>0.100000000000000</double>
                                 </property>
                                 <property name="value">
-                                 <double>2.000000000000000</double>
+                                 <double>1.000000000000000</double>
                                 </property>
                                </widget>
                               </item>


### PR DESCRIPTION
When ZUPT is enabled, OpenVINS is initialized statically. However, the initialization flag of ov_msckf::VioManager will only become true after there is initial motion excitation. Therefore, RTAB-Map would not receive the data until the camera moved. After the fix, the system can get data earlier, while remaining stationary.

Pixel noise is restored to 1. If cameras and IMU are not perfectly synchronized, it may result in fewer feature points. At this time, online offset calibration should be enabled rather than increasing pixel noise. See #1151.