### PR TITLE
Add RGBD mode for OAK camera

### DIFF
--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -97,7 +97,7 @@ private:
 	int nmsRadius_;
 	std::string blobPath_;
 	std::shared_ptr<dai::Device> device_;
-	std::shared_ptr<dai::DataOutputQueue> leftQueue_;
+	std::shared_ptr<dai::DataOutputQueue> leftOrColorQueue_;
 	std::shared_ptr<dai::DataOutputQueue> rightOrDepthQueue_;
 	std::shared_ptr<dai::DataOutputQueue> featuresQueue_;
 	std::map<double, cv::Vec3f> accBuffer_;

--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -55,13 +55,11 @@ public:
 			const Transform & localTransform = Transform::getIdentity());
 	virtual ~CameraDepthAI();
 
-	void setOutputDepth(bool enabled, int confidence = 200);
-	void setUseSpecTranslation(bool useSpecTranslation);
-	void setAlphaScaling(float alphaScaling = 0.0f);
-	void setIMUPublished(bool published);
-	void publishInterIMU(bool enabled);
-	void setLaserDotBrightness(float dotProjectormA = 0.0f);
-	void setFloodLightBrightness(float floodLightmA = 200.0f);
+	void setOutputMode(int outputMode = 0);
+	void setDepthProfile(int confThreshold = 200, int lrcThreshold = 5);
+	void setRectification(bool useSpecTranslation, float alphaScaling = 0.0f);
+	void setIMU(bool imuPublished, bool publishInterIMU);
+	void setIrBrightness(float dotProjectormA = 0.0f, float floodLightmA = 200.0f);
 	void setDetectFeatures(int detectFeatures = 0);
 	void setBlobPath(const std::string & blobPath);
 	void setGFTTDetector(bool useHarrisDetector = false, float minDistance = 7.0f, int numTargetFeatures = 1000);
@@ -80,8 +78,9 @@ private:
 	cv::Size targetSize_;
 	Transform imuLocalTransform_;
 	std::string mxidOrName_;
-	bool outputDepth_;
-	int depthConfidence_;
+	int outputMode_;
+	int confThreshold_;
+	int lrcThreshold_;
 	int resolution_;
 	bool useSpecTranslation_;
 	float alphaScaling_;

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -219,6 +219,9 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	auto monoLeft  = p.create<dai::node::MonoCamera>();
 	auto monoRight = p.create<dai::node::MonoCamera>();
 	auto stereo    = p.create<dai::node::StereoDepth>();
+	std::shared_ptr<dai::node::Camera> colorCam;
+	if(outputMode_==2)
+		colorCam = p.create<dai::node::Camera>();
 	std::shared_ptr<dai::node::IMU> imu;
 	if(imuPublished_)
 		imu = p.create<dai::node::IMU>();
@@ -243,7 +246,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		}
 	}
 
-	auto xoutLeft = p.create<dai::node::XLinkOut>();
+	auto xoutLeftOrColor = p.create<dai::node::XLinkOut>();
 	auto xoutDepthOrRight = p.create<dai::node::XLinkOut>();
 	std::shared_ptr<dai::node::XLinkOut> xoutIMU;
 	if(imuPublished_)
@@ -253,7 +256,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		xoutFeatures = p.create<dai::node::XLinkOut>();
 
 	// XLinkOut
-	xoutLeft->setStreamName("rectified_left");
+	xoutLeftOrColor->setStreamName(outputMode_<2?"rectified_left":"rectified_color");
 	xoutDepthOrRight->setStreamName(outputMode_?"depth":"rectified_right");
 	if(imuPublished_)
 		xoutIMU->setStreamName("imu");
@@ -261,9 +264,17 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		xoutFeatures->setStreamName("features");
 
 	// MonoCamera
-	monoLeft->setResolution((dai::MonoCameraProperties::SensorResolution)resolution_);
+	if(outputMode_ == 2)
+	{
+		monoLeft->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
+		monoRight->setResolution(dai::MonoCameraProperties::SensorResolution::THE_400_P);
+	}
+	else
+	{
+		monoLeft->setResolution((dai::MonoCameraProperties::SensorResolution)resolution_);
+		monoRight->setResolution((dai::MonoCameraProperties::SensorResolution)resolution_);
+	}
 	monoLeft->setCamera("left");
-	monoRight->setResolution((dai::MonoCameraProperties::SensorResolution)resolution_);
 	monoRight->setCamera("right");
 	if(detectFeatures_ == 2)
 	{
@@ -281,13 +292,16 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	}
 
 	// StereoDepth
-	stereo->setDepthAlign(dai::StereoDepthProperties::DepthAlign::RECTIFIED_LEFT);
+	if(outputMode_ == 2)
+		stereo->setDepthAlign(dai::CameraBoardSocket::CAM_A);
+	else
+		stereo->setDepthAlign(dai::StereoDepthProperties::DepthAlign::RECTIFIED_LEFT);
 	stereo->setExtendedDisparity(false);
 	stereo->setRectifyEdgeFillColor(0); // black, to better see the cutout
 	stereo->enableDistortionCorrection(true);
 	stereo->setDisparityToDepthUseSpecTranslation(useSpecTranslation_);
 	stereo->setDepthAlignmentUseSpecTranslation(useSpecTranslation_);
-	if(alphaScaling_>-1.0f)
+	if(alphaScaling_ > -1.0f)
 		stereo->setAlphaScaling(alphaScaling_);
 	stereo->initialConfig.setConfidenceThreshold(confThreshold_);
 	stereo->initialConfig.setLeftRightCheck(true);
@@ -303,14 +317,36 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	monoLeft->out.link(stereo->left);
 	monoRight->out.link(stereo->right);
 
+	if(outputMode_ == 2)
+	{
+		colorCam->setBoardSocket(dai::CameraBoardSocket::CAM_A);
+		colorCam->setSize(targetSize_.width, targetSize_.height);
+		if(this->getImageRate() > 0)
+			colorCam->setFps(this->getImageRate());
+		if(alphaScaling_ > -1.0f)
+			colorCam->setCalibrationAlpha(alphaScaling_);
+		if(detectFeatures_ == 2)
+		{
+			UWARN("SuperPoint cannot use color camera as input!");
+			detectFeatures_ = 0;
+		}
+	}
+
 	// Using VideoEncoder on PoE devices, Subpixel is not supported
 	if(deviceToUse.protocol == X_LINK_TCP_IP || mxidOrName_.find(".") != std::string::npos)
 	{
-		auto leftEnc  = p.create<dai::node::VideoEncoder>();
+		auto leftOrColorEnc  = p.create<dai::node::VideoEncoder>();
 		auto depthOrRightEnc  = p.create<dai::node::VideoEncoder>();
-		leftEnc->setDefaultProfilePreset(monoLeft->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
+		leftOrColorEnc->setDefaultProfilePreset(monoLeft->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
 		depthOrRightEnc->setDefaultProfilePreset(monoRight->getFps(), dai::VideoEncoderProperties::Profile::MJPEG);
-		stereo->rectifiedLeft.link(leftEnc->input);
+		if(outputMode_ < 2)
+		{
+			stereo->rectifiedLeft.link(leftOrColorEnc->input);
+		}
+		else
+		{
+			colorCam->video.link(leftOrColorEnc->input);
+		}
 		if(outputMode_)
 		{
 			depthOrRightEnc->setQuality(100);
@@ -320,7 +356,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		{
 			stereo->rectifiedRight.link(depthOrRightEnc->input);
 		}
-		leftEnc->bitstream.link(xoutLeft->input);
+		leftOrColorEnc->bitstream.link(xoutLeftOrColor->input);
 		depthOrRightEnc->bitstream.link(xoutDepthOrRight->input);
 	}
 	else
@@ -331,7 +367,10 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		config.costMatching.disparityWidth = dai::StereoDepthConfig::CostMatching::DisparityWidth::DISPARITY_64;
 		config.costMatching.enableCompanding = true;
 		stereo->initialConfig.set(config);
-		stereo->rectifiedLeft.link(xoutLeft->input);
+		if(outputMode_ < 2)
+			stereo->rectifiedLeft.link(xoutLeftOrColor->input);
+		else
+			colorCam->video.link(xoutLeftOrColor->input);
 		if(outputMode_)
 			stereo->depth.link(xoutDepthOrRight->input);
 		else
@@ -341,7 +380,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	if(imuPublished_)
 	{
 		// enable ACCELEROMETER_RAW and GYROSCOPE_RAW at 100 hz rate
-		imu->enableIMUSensor({dai::IMUSensor::ACCELEROMETER_RAW, dai::IMUSensor::GYROSCOPE_RAW}, 100);
+		imu->enableIMUSensor({dai::IMUSensor::ACCELEROMETER_RAW, dai::IMUSensor::GYROSCOPE_RAW}, 400);
 		// above this threshold packets will be sent in batch of X, if the host is not blocked and USB bandwidth is available
 		imu->setBatchReportThreshold(1);
 		// maximum number of IMU packets in a batch, if it's reached device will block sending until host can receive it
@@ -363,7 +402,10 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		auto cfg = gfttDetector->initialConfig.get();
 		cfg.featureMaintainer.minimumDistanceBetweenFeatures = minDistance_ * minDistance_;
 		gfttDetector->initialConfig.set(cfg);
-		stereo->rectifiedLeft.link(gfttDetector->inputImage);
+		if(outputMode_ == 2)
+			colorCam->video.link(gfttDetector->inputImage);
+		else
+			stereo->rectifiedLeft.link(gfttDetector->inputImage);
 		gfttDetector->outputFeatures.link(xoutFeatures->input);
 	}
 	else if(detectFeatures_ == 2)
@@ -385,30 +427,34 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 	UINFO("Loading eeprom calibration data");
 	dai::CalibrationHandler calibHandler = device_->readCalibration();
 
-	cv::Mat cameraMatrix, distCoeffs, new_camera_matrix;
+	auto cameraId = outputMode_<2?dai::CameraBoardSocket::CAM_B:dai::CameraBoardSocket::CAM_A;
+	cv::Mat cameraMatrix, distCoeffs, newCameraMatrix;
 
-	std::vector<std::vector<float> > matrix = calibHandler.getCameraIntrinsics(dai::CameraBoardSocket::CAM_B, dai::Size2f(targetSize_.width, targetSize_.height));
+	std::vector<std::vector<float> > matrix = calibHandler.getCameraIntrinsics(cameraId, targetSize_.width, targetSize_.height);
 	cameraMatrix = (cv::Mat_<double>(3,3) <<
 		matrix[0][0], matrix[0][1], matrix[0][2],
 		matrix[1][0], matrix[1][1], matrix[1][2],
 		matrix[2][0], matrix[2][1], matrix[2][2]);
 
-	std::vector<float> coeffs = calibHandler.getDistortionCoefficients(dai::CameraBoardSocket::CAM_B);
-	if(calibHandler.getDistortionModel(dai::CameraBoardSocket::CAM_B) == dai::CameraModel::Perspective)
+	std::vector<float> coeffs = calibHandler.getDistortionCoefficients(cameraId);
+	if(calibHandler.getDistortionModel(cameraId) == dai::CameraModel::Perspective)
 		distCoeffs = (cv::Mat_<double>(1,8) << coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4], coeffs[5], coeffs[6], coeffs[7]);
 
 	if(alphaScaling_>-1.0f)
-		new_camera_matrix = cv::getOptimalNewCameraMatrix(cameraMatrix, distCoeffs, targetSize_, alphaScaling_);
+		newCameraMatrix = cv::getOptimalNewCameraMatrix(cameraMatrix, distCoeffs, targetSize_, alphaScaling_);
 	else
-		new_camera_matrix = cameraMatrix;
+		newCameraMatrix = cameraMatrix;
 
-	double fx = new_camera_matrix.at<double>(0, 0);
-	double fy = new_camera_matrix.at<double>(1, 1);
-	double cx = new_camera_matrix.at<double>(0, 2);
-	double cy = new_camera_matrix.at<double>(1, 2);
+	double fx = newCameraMatrix.at<double>(0, 0);
+	double fy = newCameraMatrix.at<double>(1, 1);
+	double cx = newCameraMatrix.at<double>(0, 2);
+	double cy = newCameraMatrix.at<double>(1, 2);
 	double baseline = calibHandler.getBaselineDistance(dai::CameraBoardSocket::CAM_C, dai::CameraBoardSocket::CAM_B, useSpecTranslation_)/100.0;
-	UINFO("left: fx=%f fy=%f cx=%f cy=%f baseline=%f", fx, fy, cx, cy, baseline);
-	stereoModel_ = StereoCameraModel(device_->getDeviceName(), fx, fy, cx, cy, baseline, this->getLocalTransform(), targetSize_);
+	UINFO("fx=%f fy=%f cx=%f cy=%f baseline=%f", fx, fy, cx, cy, baseline);
+	if(outputMode_ == 2)
+		stereoModel_ = StereoCameraModel(device_->getDeviceName(), fx, fy, cx, cy, baseline, this->getLocalTransform(), targetSize_);
+	else
+		stereoModel_ = StereoCameraModel(device_->getDeviceName(), fx, fy, cx, cy, baseline, this->getLocalTransform()*Transform(-calibHandler.getBaselineDistance(dai::CameraBoardSocket::CAM_A)/100.0, 0, 0), targetSize_);
 
 	if(imuPublished_)
 	{
@@ -425,22 +471,29 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		{
 			imuLocalTransform_ = Transform(
 				 0, -1,  0,  0.0525,
-				 1,  0,  0,  0.0137,
+				 1,  0,  0,  0.013662,
 				 0,  0,  1,  0);
 		}
 		else if(eeprom.boardName == "DM9098")
 		{
 			imuLocalTransform_ = Transform(
-				 0,  1,  0,  0.075445,
+				 0,  1,  0,  0.037945,
 				 1,  0,  0,  0.00079,
-				 0,  0, -1, -0.007);
+				 0,  0, -1,  0);
+		}
+		else if(eeprom.boardName == "NG2094")
+		{
+			imuLocalTransform_ = Transform(
+				 0,  1,  0,  0.0374,
+				 1,  0,  0,  0.00176,
+				 0,  0, -1,  0);
 		}
 		else if(eeprom.boardName == "NG9097")
 		{
 			imuLocalTransform_ = Transform(
-				 0,  1,  0,  0.0775,
+				 0,  1,  0,  0.04,
 				 1,  0,  0,  0.020265,
-				 0,  0, -1, -0.007);
+				 0,  0, -1,  0);
 		}
 		else
 		{
@@ -484,7 +537,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 			}
 		});
 	}
-	leftQueue_ = device_->getOutputQueue("rectified_left", 8, false);
+	leftOrColorQueue_ = device_->getOutputQueue(outputMode_<2?"rectified_left":"rectified_color", 8, false);
 	rightOrDepthQueue_ = device_->getOutputQueue(outputMode_?"depth":"rectified_right", 8, false);
 	if(detectFeatures_)
 		featuresQueue_ = device_->getOutputQueue("features", 8, false);
@@ -527,20 +580,20 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 	SensorData data;
 #ifdef RTABMAP_DEPTHAI
 
-	cv::Mat left, depthOrRight;
-	auto rectifL = leftQueue_->get<dai::ImgFrame>();
+	cv::Mat leftOrColor, depthOrRight;
+	auto rectifLeftOrColor = leftOrColorQueue_->get<dai::ImgFrame>();
 	auto rectifRightOrDepth = rightOrDepthQueue_->get<dai::ImgFrame>();
 
-	while(rectifL->getSequenceNum() < rectifRightOrDepth->getSequenceNum())
-		rectifL = leftQueue_->get<dai::ImgFrame>();
-	while(rectifL->getSequenceNum() > rectifRightOrDepth->getSequenceNum())
+	while(rectifLeftOrColor->getSequenceNum() < rectifRightOrDepth->getSequenceNum())
+		rectifLeftOrColor = leftOrColorQueue_->get<dai::ImgFrame>();
+	while(rectifLeftOrColor->getSequenceNum() > rectifRightOrDepth->getSequenceNum())
 		rectifRightOrDepth = rightOrDepthQueue_->get<dai::ImgFrame>();
 
-	double stamp = std::chrono::duration<double>(rectifL->getTimestampDevice(dai::CameraExposureOffset::MIDDLE).time_since_epoch()).count();
+	double stamp = std::chrono::duration<double>(rectifLeftOrColor->getTimestampDevice(dai::CameraExposureOffset::MIDDLE).time_since_epoch()).count();
 	if(device_->getDeviceInfo().protocol == X_LINK_TCP_IP || mxidOrName_.find(".") != std::string::npos)
 	{
-		left = cv::imdecode(rectifL->getData(), cv::IMREAD_GRAYSCALE);
-		depthOrRight = cv::imdecode(rectifRightOrDepth->getData(), cv::IMREAD_GRAYSCALE);
+		leftOrColor = cv::imdecode(rectifLeftOrColor->getData(), cv::IMREAD_UNCHANGED);
+		depthOrRight = cv::imdecode(rectifRightOrDepth->getData(), cv::IMREAD_UNCHANGED);
 		if(outputMode_)
 		{
 			cv::Mat disp;
@@ -550,14 +603,14 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 	}
 	else
 	{
-		left = rectifL->getFrame(true);
-		depthOrRight = rectifRightOrDepth->getFrame(true);
+		leftOrColor = rectifLeftOrColor->getCvFrame();
+		depthOrRight = rectifRightOrDepth->getCvFrame();
 	}
 
 	if(outputMode_)
-		data = SensorData(left, depthOrRight, stereoModel_.left(), this->getNextSeqID(), stamp);
+		data = SensorData(leftOrColor, depthOrRight, stereoModel_.left(), this->getNextSeqID(), stamp);
 	else
-		data = SensorData(left, depthOrRight, stereoModel_, this->getNextSeqID(), stamp);
+		data = SensorData(leftOrColor, depthOrRight, stereoModel_, this->getNextSeqID(), stamp);
 
 	if(imuPublished_ && !publishInterIMU_)
 	{
@@ -611,7 +664,7 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 	if(detectFeatures_ == 1)
 	{
 		auto features = featuresQueue_->get<dai::TrackedFeatures>();
-		while(features->getSequenceNum() < rectifL->getSequenceNum())
+		while(features->getSequenceNum() < rectifLeftOrColor->getSequenceNum())
 			features = featuresQueue_->get<dai::TrackedFeatures>();
 		auto detectedFeatures = features->trackedFeatures;
 
@@ -623,7 +676,7 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 	else if(detectFeatures_ == 2)
 	{
 		auto features = featuresQueue_->get<dai::NNData>();
-		while(features->getSequenceNum() < rectifL->getSequenceNum())
+		while(features->getSequenceNum() < rectifLeftOrColor->getSequenceNum())
 			features = featuresQueue_->get<dai::NNData>();
 
 		auto heatmap = features->getLayerFp16("heatmap");

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -804,8 +804,9 @@ PreferencesDialog::PreferencesDialog(QWidget * parent) :
 	connect(_ui->spinBox_stereoMyntEye_irControl, SIGNAL(valueChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 
 	connect(_ui->comboBox_depthai_resolution, SIGNAL(currentIndexChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
-	connect(_ui->checkBox_depthai_depth, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
-	connect(_ui->spinBox_depthai_confidence, SIGNAL(valueChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->comboBox_depthai_output_mode, SIGNAL(currentIndexChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->spinBox_depthai_conf_threshold, SIGNAL(valueChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->spinBox_depthai_lrc_threshold, SIGNAL(valueChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->checkBox_depthai_use_spec_translation, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_alpha_scaling, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->checkBox_depthai_imu_published, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
@@ -2142,8 +2143,9 @@ void PreferencesDialog::resetSettings(QGroupBox * groupBox)
 		_ui->spinBox_stereoMyntEye_contrast->setValue(116);
 		_ui->spinBox_stereoMyntEye_irControl->setValue(0);
 		_ui->comboBox_depthai_resolution->setCurrentIndex(1);
-		_ui->checkBox_depthai_depth->setChecked(false);
-		_ui->spinBox_depthai_confidence->setValue(200);
+		_ui->comboBox_depthai_output_mode->setCurrentIndex(0);
+		_ui->spinBox_depthai_conf_threshold->setValue(200);
+		_ui->spinBox_depthai_lrc_threshold->setValue(5);
 		_ui->checkBox_depthai_use_spec_translation->setChecked(false);
 		_ui->doubleSpinBox_depthai_alpha_scaling->setValue(0.0);
 		_ui->checkBox_depthai_imu_published->setChecked(true);
@@ -2633,8 +2635,9 @@ void PreferencesDialog::readCameraSettings(const QString & filePath)
 
 	settings.beginGroup("DepthAI");
 	_ui->comboBox_depthai_resolution->setCurrentIndex(settings.value("resolution", _ui->comboBox_depthai_resolution->currentIndex()).toInt());
-	_ui->checkBox_depthai_depth->setChecked(settings.value("depth", _ui->checkBox_depthai_depth->isChecked()).toBool());
-	_ui->spinBox_depthai_confidence->setValue(settings.value("confidence", _ui->spinBox_depthai_confidence->value()).toInt());
+	_ui->comboBox_depthai_output_mode->setCurrentIndex(settings.value("output_mode", _ui->comboBox_depthai_output_mode->currentIndex()).toInt());
+	_ui->spinBox_depthai_conf_threshold->setValue(settings.value("conf_threshold", _ui->spinBox_depthai_conf_threshold->value()).toInt());
+	_ui->spinBox_depthai_lrc_threshold->setValue(settings.value("lrc_threshold", _ui->spinBox_depthai_lrc_threshold->value()).toInt());
 	_ui->checkBox_depthai_use_spec_translation->setChecked(settings.value("use_spec_translation", _ui->checkBox_depthai_use_spec_translation->isChecked()).toBool());
 	_ui->doubleSpinBox_depthai_alpha_scaling->setValue(settings.value("alpha_scaling", _ui->doubleSpinBox_depthai_alpha_scaling->value()).toDouble());
 	_ui->checkBox_depthai_imu_published->setChecked(settings.value("imu_published", _ui->checkBox_depthai_imu_published->isChecked()).toBool());
@@ -3167,8 +3170,9 @@ void PreferencesDialog::writeCameraSettings(const QString & filePath) const
 
 	settings.beginGroup("DepthAI");
 	settings.setValue("resolution",            _ui->comboBox_depthai_resolution->currentIndex());
-	settings.setValue("depth",                 _ui->checkBox_depthai_depth->isChecked());
-	settings.setValue("confidence",            _ui->spinBox_depthai_confidence->value());
+	settings.setValue("output_mode",           _ui->comboBox_depthai_output_mode->currentIndex());
+	settings.setValue("conf_threshold",        _ui->spinBox_depthai_conf_threshold->value());
+	settings.setValue("lrc_threshold",         _ui->spinBox_depthai_lrc_threshold->value());
 	settings.setValue("use_spec_translation",  _ui->checkBox_depthai_use_spec_translation->isChecked());
 	settings.setValue("alpha_scaling",         _ui->doubleSpinBox_depthai_alpha_scaling->value());
 	settings.setValue("imu_published",         _ui->checkBox_depthai_imu_published->isChecked());
@@ -6486,13 +6490,11 @@ Camera * PreferencesDialog::createCamera(
 			_ui->comboBox_depthai_resolution->currentIndex(),
 			this->getGeneralInputRate(),
 			this->getSourceLocalTransform());
-		((CameraDepthAI*)camera)->setOutputDepth(_ui->checkBox_depthai_depth->isChecked(), _ui->spinBox_depthai_confidence->value());
-		((CameraDepthAI*)camera)->setUseSpecTranslation(_ui->checkBox_depthai_use_spec_translation->isChecked());
-		((CameraDepthAI*)camera)->setAlphaScaling(_ui->doubleSpinBox_depthai_alpha_scaling->value());
-		((CameraDepthAI*)camera)->setIMUPublished(_ui->checkBox_depthai_imu_published->isChecked());
-		((CameraDepthAI*)camera)->publishInterIMU(_ui->checkbox_publishInterIMU->isChecked());
-		((CameraDepthAI*)camera)->setLaserDotBrightness(_ui->doubleSpinBox_depthai_laser_dot_brightness->value());
-		((CameraDepthAI*)camera)->setFloodLightBrightness(_ui->doubleSpinBox_depthai_floodlight_brightness->value());
+		((CameraDepthAI*)camera)->setOutputMode(_ui->comboBox_depthai_output_mode->currentIndex());
+		((CameraDepthAI*)camera)->setDepthProfile(_ui->spinBox_depthai_conf_threshold->value(), _ui->spinBox_depthai_lrc_threshold->value());
+		((CameraDepthAI*)camera)->setRectification(_ui->checkBox_depthai_use_spec_translation->isChecked(), _ui->doubleSpinBox_depthai_alpha_scaling->value());
+		((CameraDepthAI*)camera)->setIMU(_ui->checkBox_depthai_imu_published->isChecked(), _ui->checkbox_publishInterIMU->isChecked());
+		((CameraDepthAI*)camera)->setIrBrightness(_ui->doubleSpinBox_depthai_laser_dot_brightness->value(), _ui->doubleSpinBox_depthai_floodlight_brightness->value());
 		((CameraDepthAI*)camera)->setDetectFeatures(_ui->comboBox_depthai_detect_features->currentIndex());
 		((CameraDepthAI*)camera)->setBlobPath(_ui->lineEdit_depthai_blob_path->text().toStdString());
 		if(_ui->comboBox_depthai_detect_features->currentIndex() == 1)

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -5905,7 +5905,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </item>
                                    </widget>
                                   </item>
-                                  <item row="4" column="0">
+                                  <item row="5" column="0">
                                    <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_alpha_scaling">
                                     <property name="minimum">
                                      <double>-1.000000000000000</double>
@@ -5924,7 +5924,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                   <item row="2" column="1">
                                    <widget class="QLabel" name="label_627">
                                     <property name="text">
-                                     <string>Depth confidence.</string>
+                                     <string>Confidence threshold.</string>
                                     </property>
                                     <property name="wordWrap">
                                      <bool>true</bool>
@@ -5934,7 +5934,20 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="6" column="0">
+                                  <item row="3" column="1">
+                                   <widget class="QLabel" name="label_741">
+                                    <property name="text">
+                                     <string>Left-right check threshold.</string>
+                                    </property>
+                                    <property name="wordWrap">
+                                     <bool>true</bool>
+                                    </property>
+                                    <property name="textInteractionFlags">
+                                     <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item row="7" column="0">
                                    <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_laser_dot_brightness">
                                     <property name="suffix">
                                      <string> mA</string>
@@ -5947,14 +5960,14 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="5" column="0">
+                                  <item row="6" column="0">
                                    <widget class="QCheckBox" name="checkBox_depthai_imu_published">
                                     <property name="text">
                                      <string/>
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="7" column="1">
+                                  <item row="8" column="1">
                                    <widget class="QLabel" name="label_677">
                                     <property name="text">
                                      <string>Floodlight brightness.</string>
@@ -5967,7 +5980,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="6" column="1">
+                                  <item row="7" column="1">
                                    <widget class="QLabel" name="label_676">
                                     <property name="text">
                                      <string>Laser dot brightness.</string>
@@ -5980,7 +5993,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="3" column="1">
+                                  <item row="4" column="1">
                                    <widget class="QLabel" name="label_646">
                                     <property name="text">
                                      <string>Use the translation information from the board design data (not the calibration data).</string>
@@ -6007,13 +6020,31 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                    </widget>
                                   </item>
                                   <item row="1" column="0">
-                                   <widget class="QCheckBox" name="checkBox_depthai_depth">
-                                    <property name="text">
-                                     <string/>
+                                   <widget class="QComboBox" name="comboBox_depthai_output_mode">
+                                    <property name="currentIndex">
+                                     <number>0</number>
                                     </property>
+                                    <property name="sizeAdjustPolicy">
+                                     <enum>QComboBox::AdjustToContents</enum>
+                                    </property>
+                                    <item>
+                                     <property name="text">
+                                      <string>Stereo</string>
+                                     </property>
+                                    </item>
+                                    <item>
+                                     <property name="text">
+                                      <string>Mono+Depth</string>
+                                     </property>
+                                    </item>
+                                    <item>
+                                     <property name="text">
+                                      <string>Color+Depth</string>
+                                     </property>
+                                    </item>
                                    </widget>
                                   </item>
-                                  <item row="4" column="1">
+                                  <item row="5" column="1">
                                    <widget class="QLabel" name="label_678">
                                     <property name="text">
                                      <string>Free scaling parameter between 0 (when all the pixels in the undistorted image are valid) and 1 (when all the source image pixels are retained in the undistorted image). On some high distortion lenses, and/or due to rectification (image rotated) invalid areas may appear even with alpha=0, in these cases alpha &lt; 0.0 helps removing invalid areas. If alpha is set to -1, old rectification policy is used.</string>
@@ -6027,7 +6058,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                    </widget>
                                   </item>
                                   <item row="2" column="0">
-                                   <widget class="QSpinBox" name="spinBox_depthai_confidence">
+                                   <widget class="QSpinBox" name="spinBox_depthai_conf_threshold">
                                     <property name="minimum">
                                      <number>0</number>
                                     </property>
@@ -6039,7 +6070,20 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="5" column="1">
+                                  <item row="3" column="0">
+                                   <widget class="QSpinBox" name="spinBox_depthai_lrc_threshold">
+                                    <property name="minimum">
+                                     <number>0</number>
+                                    </property>
+                                    <property name="maximum">
+                                     <number>255</number>
+                                    </property>
+                                    <property name="value">
+                                     <number>5</number>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item row="6" column="1">
                                    <widget class="QLabel" name="label_650">
                                     <property name="text">
                                      <string>IMU published</string>
@@ -6052,7 +6096,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="3" column="0">
+                                  <item row="4" column="0">
                                    <widget class="QCheckBox" name="checkBox_depthai_use_spec_translation">
                                     <property name="text">
                                      <string/>
@@ -6062,7 +6106,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                   <item row="1" column="1">
                                    <widget class="QLabel" name="label_625">
                                     <property name="text">
-                                     <string>Output depth.</string>
+                                     <string>Output mode.</string>
                                     </property>
                                     <property name="wordWrap">
                                      <bool>true</bool>
@@ -6072,7 +6116,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="7" column="0">
+                                  <item row="8" column="0">
                                    <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_floodlight_brightness">
                                     <property name="suffix">
                                      <string> mA</string>
@@ -6085,7 +6129,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="8" column="0">
+                                  <item row="9" column="0">
                                    <widget class="QComboBox" name="comboBox_depthai_detect_features">
                                     <property name="currentIndex">
                                      <number>0</number>
@@ -6110,7 +6154,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </item>
                                    </widget>
                                   </item>
-                                  <item row="8" column="1">
+                                  <item row="9" column="1">
                                    <widget class="QLabel" name="label_679">
                                     <property name="text">
                                      <string>On-device feature detector.</string>
@@ -6123,7 +6167,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </property>
                                    </widget>
                                   </item>
-                                  <item row="9" column="0">
+                                  <item row="10" column="0">
                                    <layout class="QHBoxLayout" name="horizontalLayout_15" stretch="0,1">
                                     <item>
                                      <widget class="QToolButton" name="toolButton_depthai_blob_path">
@@ -6147,7 +6191,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                     </item>
                                    </layout>
                                   </item>
-                                  <item row="9" column="1">
+                                  <item row="10" column="1">
                                    <widget class="QLabel" name="label_680">
                                     <property name="text">
                                      <string>Path to SuperPoint blob file.</string>


### PR DESCRIPTION
I added RGBD mode for OAK cameras, but only those models with global shutter color cameras are supported. There are actually only 2 models in the [supported sensors](https://docs.luxonis.com/projects/hardware/en/latest/pages/articles/supported_sensors/) list, [OV9782](https://docs.luxonis.com/projects/hardware/en/latest/pages/articles/sensors/ov9782/) and [AR0234](https://docs.luxonis.com/projects/hardware/en/latest/pages/articles/sensors/ar0234/). Their resolutions happen to be consistent with the mono camera's resolution list, so adding list items can be avoided. I'm using [OAK-D Pro W Dev](https://shop.luxonis.com/products/oak-d-pro-w-dev), so I added the NG2094 board. As for AR0234, it is currently only used in OAK-D LR and needs to be tested and updated later.

Some adjustments have also been made to local transforms to make the configuration of different modes more consistent. Now the center camera is used as the camera base frame, and the left and right cameras and IMU will calculate offset based on this. This is also consistent with [the URDF definition in depthai-ros](https://github.com/luxonis/depthai-ros/blob/humble/depthai_descriptions/urdf/include/base_macro.urdf.xacro). The data in URDF is actually not that official. It was actually what I measured last time.

I encountered some performance issues when three cameras are working simultaneously. This is a bit strange, because judging from depthai's debugging info, there is no problem with hardware resource allocation. But there are at least two ways to avoid it, one is to reduce the depth resolution, and the other is to disable subpixel. So when using a USB camera, the depth resolution is limited to 400P. In addition, v2.23.0 of depthai-core is required, otherwise there will be an issue with depth image alignment.

https://github.com/introlab/rtabmap/assets/22918715/2a78d8a9-5a26-4fe5-ade8-9cf7b95cb97e