### PR TITLE
OAK Internal Sync & DepthAI HF-Net Support

### DIFF
--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -59,7 +59,7 @@ public:
 	void setDepthProfile(int confThreshold = 200, int lrcThreshold = 5);
 	void setRectification(bool useSpecTranslation, float alphaScaling = 0.0f);
 	void setIMU(bool imuPublished, bool publishInterIMU);
-	void setIrBrightness(float dotProjectormA = 0.0f, float floodLightmA = 200.0f);
+	void setIrIntensity(float dotIntensity = 0.0f, float floodIntensity = 0.0f);
 	void setDetectFeatures(int detectFeatures = 0);
 	void setBlobPath(const std::string & blobPath);
 	void setGFTTDetector(bool useHarrisDetector = false, float minDistance = 7.0f, int numTargetFeatures = 1000);
@@ -86,8 +86,8 @@ private:
 	float alphaScaling_;
 	bool imuPublished_;
 	bool publishInterIMU_;
-	float dotProjectormA_;
-	float floodLightmA_;
+	float dotIntensity_;
+	float floodIntensity_;
 	int detectFeatures_;
 	bool useHarrisDetector_;
 	float minDistance_;

--- a/corelib/include/rtabmap/core/camera/CameraDepthAI.h
+++ b/corelib/include/rtabmap/core/camera/CameraDepthAI.h
@@ -97,9 +97,7 @@ private:
 	int nmsRadius_;
 	std::string blobPath_;
 	std::shared_ptr<dai::Device> device_;
-	std::shared_ptr<dai::DataOutputQueue> leftOrColorQueue_;
-	std::shared_ptr<dai::DataOutputQueue> rightOrDepthQueue_;
-	std::shared_ptr<dai::DataOutputQueue> featuresQueue_;
+	std::shared_ptr<dai::DataOutputQueue> cameraQueue_;
 	std::map<double, cv::Vec3f> accBuffer_;
 	std::map<double, cv::Vec3f> gyroBuffer_;
 	UMutex imuMutex_;

--- a/corelib/src/DBDriverSqlite3.cpp
+++ b/corelib/src/DBDriverSqlite3.cpp
@@ -6728,7 +6728,7 @@ void DBDriverSqlite3::stepGlobalDescriptor(sqlite3_stmt * ppStmt,
 
 	//data
 	std::vector<unsigned char> dataBytes = rtabmap::compressData(descriptor.data());
-	if(infoBytes.empty())
+	if(dataBytes.empty())
 	{
 		rc = sqlite3_bind_null(ppStmt, index++);
 	}

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -728,6 +728,8 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 		descriptors = descriptors.reshape(1);
 
 		data.setFeatures(keypoints, std::vector<cv::Point3f>(), descriptors);
+		if(detectFeatures_ == 3)
+			data.addGlobalDescriptor(GlobalDescriptor(1, cv::Mat(1, global_descriptor.size(), CV_32FC1, global_descriptor.data())));
 	}
 
 #else

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -373,7 +373,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 			stereo->rectifiedRight.link(sync->inputs["right"]);
 	}
 
-	sync->setSyncThreshold(std::chrono::milliseconds(100));
+	sync->setSyncThreshold(std::chrono::milliseconds(int(500 / monoLeft->getFps())));
 	sync->out.link(xoutCamera->input);
 
 	if(imuPublished_)

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -62,8 +62,8 @@ CameraDepthAI::CameraDepthAI(
 	alphaScaling_(0.0),
 	imuPublished_(true),
 	publishInterIMU_(false),
-	dotProjectormA_(0.0),
-	floodLightmA_(200.0),
+	dotIntensity_(0.0),
+	floodIntensity_(0.0),
 	detectFeatures_(0),
 	useHarrisDetector_(false),
 	minDistance_(7.0),
@@ -127,11 +127,11 @@ void CameraDepthAI::setIMU(bool imuPublished, bool publishInterIMU)
 #endif
 }
 
-void CameraDepthAI::setIrBrightness(float dotProjectormA, float floodLightmA)
+void CameraDepthAI::setIrIntensity(float dotIntensity, float floodIntensity)
 {
 #ifdef RTABMAP_DEPTHAI
-	dotProjectormA_ = dotProjectormA;
-	floodLightmA_ = floodLightmA;
+	dotIntensity_ = dotIntensity;
+	floodIntensity_ = floodIntensity;
 #else
 	UERROR("CameraDepthAI: RTAB-Map is not built with depthai-core support!");
 #endif
@@ -535,11 +535,10 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		});
 	}
 
-	std::vector<std::tuple<std::string, int, int>> irDrivers = device_->getIrDrivers();
-	if(!irDrivers.empty())
+	if(!device_->getIrDrivers().empty())
 	{
-		device_->setIrLaserDotProjectorBrightness(dotProjectormA_);
-		device_->setIrFloodLightBrightness(floodLightmA_);
+		device_->setIrLaserDotProjectorIntensity(dotIntensity_);
+		device_->setIrFloodLightIntensity(floodIntensity_);
 	}
 
 	uSleep(2000); // avoid bad frames on start

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -319,6 +319,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 		if(alphaScaling_ > -1.0f)
 			colorCam->setCalibrationAlpha(alphaScaling_);
 	}
+	this->setImageRate(0);
 
 	// Using VideoEncoder on PoE devices, Subpixel is not supported
 	if(deviceToUse.protocol == X_LINK_TCP_IP || mxidOrName_.find(".") != std::string::npos)

--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -378,8 +378,8 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 
 	if(imuPublished_)
 	{
-		// enable ACCELEROMETER_RAW and GYROSCOPE_RAW at 100 hz rate
-		imu->enableIMUSensor({dai::IMUSensor::ACCELEROMETER_RAW, dai::IMUSensor::GYROSCOPE_RAW}, 100);
+		// enable ACCELEROMETER_RAW and GYROSCOPE_RAW at 200 hz rate
+		imu->enableIMUSensor({dai::IMUSensor::ACCELEROMETER_RAW, dai::IMUSensor::GYROSCOPE_RAW}, 200);
 		// above this threshold packets will be sent in batch of X, if the host is not blocked and USB bandwidth is available
 		imu->setBatchReportThreshold(1);
 		// maximum number of IMU packets in a batch, if it's reached device will block sending until host can receive it

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -817,8 +817,8 @@ PreferencesDialog::PreferencesDialog(QWidget * parent) :
 	connect(_ui->checkBox_depthai_use_spec_translation, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->doubleSpinBox_depthai_alpha_scaling, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->checkBox_depthai_imu_published, SIGNAL(stateChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
-	connect(_ui->doubleSpinBox_depthai_laser_dot_brightness, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
-	connect(_ui->doubleSpinBox_depthai_floodlight_brightness, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->doubleSpinBox_depthai_dot_intensity, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
+	connect(_ui->doubleSpinBox_depthai_flood_intensity, SIGNAL(valueChanged(double)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->comboBox_depthai_detect_features, SIGNAL(currentIndexChanged(int)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->lineEdit_depthai_blob_path, SIGNAL(textChanged(const QString &)), this, SLOT(makeObsoleteSourcePanel()));
 	connect(_ui->toolButton_depthai_blob_path, SIGNAL(clicked()), this, SLOT(selectSourceDepthaiBlobPath()));
@@ -2158,8 +2158,8 @@ void PreferencesDialog::resetSettings(QGroupBox * groupBox)
 		_ui->checkBox_depthai_use_spec_translation->setChecked(false);
 		_ui->doubleSpinBox_depthai_alpha_scaling->setValue(0.0);
 		_ui->checkBox_depthai_imu_published->setChecked(true);
-		_ui->doubleSpinBox_depthai_laser_dot_brightness->setValue(0.0);
-		_ui->doubleSpinBox_depthai_floodlight_brightness->setValue(200.0);
+		_ui->doubleSpinBox_depthai_dot_intensity->setValue(0.0);
+		_ui->doubleSpinBox_depthai_flood_intensity->setValue(0.0);
 		_ui->comboBox_depthai_detect_features->setCurrentIndex(0);
 		_ui->lineEdit_depthai_blob_path->clear();
 
@@ -2651,8 +2651,8 @@ void PreferencesDialog::readCameraSettings(const QString & filePath)
 	_ui->checkBox_depthai_use_spec_translation->setChecked(settings.value("use_spec_translation", _ui->checkBox_depthai_use_spec_translation->isChecked()).toBool());
 	_ui->doubleSpinBox_depthai_alpha_scaling->setValue(settings.value("alpha_scaling", _ui->doubleSpinBox_depthai_alpha_scaling->value()).toDouble());
 	_ui->checkBox_depthai_imu_published->setChecked(settings.value("imu_published", _ui->checkBox_depthai_imu_published->isChecked()).toBool());
-	_ui->doubleSpinBox_depthai_laser_dot_brightness->setValue(settings.value("laser_dot_brightness", _ui->doubleSpinBox_depthai_laser_dot_brightness->value()).toDouble());
-	_ui->doubleSpinBox_depthai_floodlight_brightness->setValue(settings.value("floodlight_brightness", _ui->doubleSpinBox_depthai_floodlight_brightness->value()).toDouble());
+	_ui->doubleSpinBox_depthai_dot_intensity->setValue(settings.value("dot_intensity", _ui->doubleSpinBox_depthai_dot_intensity->value()).toDouble());
+	_ui->doubleSpinBox_depthai_flood_intensity->setValue(settings.value("flood_intensity", _ui->doubleSpinBox_depthai_flood_intensity->value()).toDouble());
 	_ui->comboBox_depthai_detect_features->setCurrentIndex(settings.value("detect_features", _ui->comboBox_depthai_detect_features->currentIndex()).toInt());
 	_ui->lineEdit_depthai_blob_path->setText(settings.value("blob_path", _ui->lineEdit_depthai_blob_path->text()).toString());
 	settings.endGroup(); // DepthAI
@@ -3188,8 +3188,8 @@ void PreferencesDialog::writeCameraSettings(const QString & filePath) const
 	settings.setValue("use_spec_translation",  _ui->checkBox_depthai_use_spec_translation->isChecked());
 	settings.setValue("alpha_scaling",         _ui->doubleSpinBox_depthai_alpha_scaling->value());
 	settings.setValue("imu_published",         _ui->checkBox_depthai_imu_published->isChecked());
-	settings.setValue("laser_dot_brightness",  _ui->doubleSpinBox_depthai_laser_dot_brightness->value());
-	settings.setValue("floodlight_brightness", _ui->doubleSpinBox_depthai_floodlight_brightness->value());
+	settings.setValue("dot_intensity",         _ui->doubleSpinBox_depthai_dot_intensity->value());
+	settings.setValue("flood_intensity",       _ui->doubleSpinBox_depthai_flood_intensity->value());
 	settings.setValue("detect_features",       _ui->comboBox_depthai_detect_features->currentIndex());
 	settings.setValue("blob_path",             _ui->lineEdit_depthai_blob_path->text());
 	settings.endGroup(); // DepthAI
@@ -6510,7 +6510,7 @@ Camera * PreferencesDialog::createCamera(
 		((CameraDepthAI*)camera)->setDepthProfile(_ui->spinBox_depthai_conf_threshold->value(), _ui->spinBox_depthai_lrc_threshold->value());
 		((CameraDepthAI*)camera)->setRectification(_ui->checkBox_depthai_use_spec_translation->isChecked(), _ui->doubleSpinBox_depthai_alpha_scaling->value());
 		((CameraDepthAI*)camera)->setIMU(_ui->checkBox_depthai_imu_published->isChecked(), _ui->checkbox_publishInterIMU->isChecked());
-		((CameraDepthAI*)camera)->setIrBrightness(_ui->doubleSpinBox_depthai_laser_dot_brightness->value(), _ui->doubleSpinBox_depthai_floodlight_brightness->value());
+		((CameraDepthAI*)camera)->setIrIntensity(_ui->doubleSpinBox_depthai_dot_intensity->value(), _ui->doubleSpinBox_depthai_flood_intensity->value());
 		((CameraDepthAI*)camera)->setDetectFeatures(_ui->comboBox_depthai_detect_features->currentIndex());
 		((CameraDepthAI*)camera)->setBlobPath(_ui->lineEdit_depthai_blob_path->text().toStdString());
 		if(_ui->comboBox_depthai_detect_features->currentIndex() == 1)

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -6517,7 +6517,7 @@ Camera * PreferencesDialog::createCamera(
 		{
 			((CameraDepthAI*)camera)->setGFTTDetector(_ui->checkBox_GFTT_useHarrisDetector->isChecked(), _ui->doubleSpinBox_GFTT_minDistance->value(), _ui->reextract_maxFeatures->value());
 		}
-		else if(_ui->comboBox_depthai_detect_features->currentIndex() == 2)
+		else if(_ui->comboBox_depthai_detect_features->currentIndex() >= 2)
 		{
 			((CameraDepthAI*)camera)->setSuperPointDetector(_ui->doubleSpinBox_sptorch_threshold->value(), _ui->checkBox_sptorch_nms->isChecked(), _ui->spinBox_sptorch_minDistance->value());
 		}

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -5974,12 +5974,12 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                    </widget>
                                   </item>
                                   <item row="7" column="0">
-                                   <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_laser_dot_brightness">
-                                    <property name="suffix">
-                                     <string> mA</string>
-                                    </property>
+                                   <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_dot_intensity">
                                     <property name="maximum">
-                                     <double>1200.000000000000000</double>
+                                     <double>1.000000000000000</double>
+                                    </property>
+                                    <property name="singleStep">
+                                     <double>0.050000000000000</double>
                                     </property>
                                     <property name="value">
                                      <double>0.000000000000000</double>
@@ -5996,7 +5996,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                   <item row="8" column="1">
                                    <widget class="QLabel" name="label_677">
                                     <property name="text">
-                                     <string>Floodlight brightness.</string>
+                                     <string>IR flood light intensity.</string>
                                     </property>
                                     <property name="wordWrap">
                                      <bool>true</bool>
@@ -6009,7 +6009,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                   <item row="7" column="1">
                                    <widget class="QLabel" name="label_676">
                                     <property name="text">
-                                     <string>Laser dot brightness.</string>
+                                     <string>IR laser dot projector intensity.</string>
                                     </property>
                                     <property name="wordWrap">
                                      <bool>true</bool>
@@ -6143,15 +6143,15 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                    </widget>
                                   </item>
                                   <item row="8" column="0">
-                                   <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_floodlight_brightness">
-                                    <property name="suffix">
-                                     <string> mA</string>
-                                    </property>
+                                   <widget class="QDoubleSpinBox" name="doubleSpinBox_depthai_flood_intensity">
                                     <property name="maximum">
-                                     <double>1500.000000000000000</double>
+                                     <double>1.000000000000000</double>
+                                    </property>
+                                    <property name="singleStep">
+                                     <double>0.050000000000000</double>
                                     </property>
                                     <property name="value">
-                                     <double>200.000000000000000</double>
+                                     <double>0.000000000000000</double>
                                     </property>
                                    </widget>
                                   </item>

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -6178,6 +6178,11 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                       <string>SuperPoint</string>
                                      </property>
                                     </item>
+                                    <item>
+                                      <property name="text">
+                                       <string>HF-Net</string>
+                                      </property>
+                                     </item>
                                    </widget>
                                   </item>
                                   <item row="9" column="1">
@@ -6220,7 +6225,7 @@ when using the file type, logs are saved in LogRtabmap.txt (located in the worki
                                   <item row="10" column="1">
                                    <widget class="QLabel" name="label_680">
                                     <property name="text">
-                                     <string>Path to SuperPoint blob file.</string>
+                                     <string>Path to MyriadX blob file.</string>
                                     </property>
                                     <property name="wordWrap">
                                      <bool>true</bool>


### PR DESCRIPTION
All messages except IMU are synchronized using the Sync node introduced in [v2.24.0](https://github.com/luxonis/depthai-core/releases/tag/v2.24.0). LGTM, but I'll keep this PR as a draft until the depthai in ROS repo is updated to 2.24.0. In addition, they have not added doc for Sync node yet, only providing new examples. We can do more inspections and tests during this time.
The IR settings have also been changed to new methods in v2.24.0.