### PR TITLE
not limitKps inside Feature2D::generateKeypoints when using pyDetector

### DIFF
--- a/corelib/src/Features2d.cpp
+++ b/corelib/src/Features2d.cpp
@@ -741,13 +741,13 @@ std::vector<cv::KeyPoint> Feature2D::generateKeypoints(const cv::Mat & image, co
 			if(roi.x || roi.y)
 			{
 				// Adjust keypoint position to raw image
-				for(std::vector<cv::KeyPoint>::iterator iter=sub_keypoints.begin(); iter!=sub_keypoints.end(); ++iter)
+				for(std::vector<cv::KeyPoint>::iterator iter=subKeypoints.begin(); iter!=subKeypoints.end(); ++iter)
 				{
 					iter->pt.x += roi.x;
 					iter->pt.y += roi.y;
 				}
 			}
-			keypoints.insert( keypoints.end(), sub_keypoints.begin(), sub_keypoints.end() );
+			keypoints.insert( keypoints.end(), subKeypoints.begin(), subKeypoints.end() );
 		}
 	}
 	UDEBUG("Keypoints extraction time = %f s, keypoints extracted = %d (grid=%dx%d, mask empty=%d)",
@@ -2121,6 +2121,24 @@ std::vector<cv::KeyPoint> ORBOctree::generateKeypointsImpl(const cv::Mat & image
 	}
 
 	(*_orb)(imgRoi, maskRoi, keypoints, descriptors_);
+
+	// OrbOctree ignores the mask, so we have to apply it manually here
+	if(!keypoints.empty() && !maskRoi.empty())
+	{
+		std::vector<cv::KeyPoint> validKeypoints;
+		validKeypoints.reserve(keypoints.size());
+		cv::Mat validDescriptors;
+		for(size_t i=0; i<keypoints.size(); ++i)
+		{
+			if(maskRoi.at<unsigned char>(keypoints[i].pt.y+roi.y, keypoints[i].pt.x+roi.x) != 0)
+			{
+				validKeypoints.push_back(keypoints[i]);
+				validDescriptors.push_back(descriptors_.row(i));
+			}
+		}
+		keypoints = validKeypoints;
+		descriptors_ = validDescriptors;
+	}
 
 	if((int)keypoints.size() > this->getMaxFeatures())
 	{

--- a/corelib/src/Features2d.cpp
+++ b/corelib/src/Features2d.cpp
@@ -734,17 +734,20 @@ std::vector<cv::KeyPoint> Feature2D::generateKeypoints(const cv::Mat & image, co
 			cv::Rect roi(globalRoi.x + j*colSize, globalRoi.y + i*rowSize, colSize, rowSize);
 			std::vector<cv::KeyPoint> subKeypoints;
 			subKeypoints = this->generateKeypointsImpl(image, roi, mask);
-			limitKeypoints(subKeypoints, maxFeatures);
+			if (this->getType() != Feature2D::Type::kFeaturePyDetector)
+			{
+				limitKeypoints(subKeypoints, maxFeatures);
+			}
 			if(roi.x || roi.y)
 			{
 				// Adjust keypoint position to raw image
-				for(std::vector<cv::KeyPoint>::iterator iter=subKeypoints.begin(); iter!=subKeypoints.end(); ++iter)
+				for(std::vector<cv::KeyPoint>::iterator iter=sub_keypoints.begin(); iter!=sub_keypoints.end(); ++iter)
 				{
 					iter->pt.x += roi.x;
 					iter->pt.y += roi.y;
 				}
 			}
-			keypoints.insert( keypoints.end(), subKeypoints.begin(), subKeypoints.end() );
+			keypoints.insert( keypoints.end(), sub_keypoints.begin(), sub_keypoints.end() );
 		}
 	}
 	UDEBUG("Keypoints extraction time = %f s, keypoints extracted = %d (grid=%dx%d, mask empty=%d)",
@@ -2118,24 +2121,6 @@ std::vector<cv::KeyPoint> ORBOctree::generateKeypointsImpl(const cv::Mat & image
 	}
 
 	(*_orb)(imgRoi, maskRoi, keypoints, descriptors_);
-
-	// OrbOctree ignores the mask, so we have to apply it manually here
-	if(!keypoints.empty() && !maskRoi.empty())
-	{
-		std::vector<cv::KeyPoint> validKeypoints;
-		validKeypoints.reserve(keypoints.size());
-		cv::Mat validDescriptors;
-		for(size_t i=0; i<keypoints.size(); ++i)
-		{
-			if(maskRoi.at<unsigned char>(keypoints[i].pt.y+roi.y, keypoints[i].pt.x+roi.x) != 0)
-			{
-				validKeypoints.push_back(keypoints[i]);
-				validDescriptors.push_back(descriptors_.row(i));
-			}
-		}
-		keypoints = validKeypoints;
-		descriptors_ = validDescriptors;
-	}
 
 	if((int)keypoints.size() > this->getMaxFeatures())
 	{


### PR DESCRIPTION
This only happens with SuperPoint. Rtabmap will limit key points if exceeds the limit set by Kp/MaxFeatures THEN it will generate descriptors based on extracted key points. It will work classic Features Extraction method. However, SuperPoint will generate key points and descriptors at the same time, if the limit key points method calls inside the extract key point method it will lead to a mismatched number of key points and descriptors later when the generate descriptor method calls. It is solved by ignoring the limit key points method inside the generate key point method and only limiting key points after generating the descriptors if necessary.