### PR TITLE
copy global descriptor

### DIFF
--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -800,7 +800,7 @@ SensorData CameraDepthAI::captureImage(CameraInfo * info)
 
 		data.setFeatures(keypoints, std::vector<cv::Point3f>(), descriptors);
 		if(detectFeatures_ == 3)
-			data.addGlobalDescriptor(GlobalDescriptor(1, cv::Mat(1, global_descriptor.size(), CV_32FC1, global_descriptor.data())));
+			data.addGlobalDescriptor(GlobalDescriptor(1, cv::Mat(1, global_descriptor.size(), CV_32FC1, global_descriptor.data()).clone()));
 	}
 
 #else


### PR DESCRIPTION
The inference is correct using HF-Net blob file. I made a silly mistake when converting to cv::Mat. This solves https://github.com/introlab/rtabmap/issues/1215#issuecomment-2002006330. Now I can get similar results to https://github.com/introlab/rtabmap/issues/1105#issuecomment-2031099209 in online testing.