### PR TITLE
adjust likelihood using z-score

### DIFF
--- a/corelib/src/Rtabmap.cpp
+++ b/corelib/src/Rtabmap.cpp
@@ -5265,15 +5265,14 @@ void Rtabmap::adjustLikelihood(std::map<int, float> & likelihood) const
 
 
 	//Adjust likelihood with mean and standard deviation (see Angeli phd)
-	float epsilon = 0.0001;
 	float max = 0.0f;
 	int maxId = 0;
 	for(std::map<int, float>::iterator iter=++likelihood.begin(); iter!= likelihood.end(); ++iter)
 	{
 		float value = iter->second;
-		if(value > mean+stdDev && mean)
+		if(value > mean+stdDev && stdDev)
 		{
-			iter->second = (value-(stdDev-epsilon))/mean;
+			iter->second = (value-mean)/stdDev;
 			if(value > max)
 			{
 				max = value;
@@ -5295,9 +5294,9 @@ void Rtabmap::adjustLikelihood(std::map<int, float> & likelihood) const
 		}
 	}
 
-	if(stdDev > epsilon && max)
+	if(max > mean)
 	{
-		likelihood.begin()->second = mean/stdDev + 1.0f;
+		likelihood.begin()->second = stdDev/(max-mean) + 1.0f;
 	}
 	else
 	{


### PR DESCRIPTION
I constructed a new method to adjust the likelihood, as a solution to https://github.com/introlab/rtabmap/issues/1105#issuecomment-2031099209. It should be compatible with previous similarity evaluation methods, as well as VLAD. The idea is to calculate z-score for values ​​greater than μ + σ. This eliminates the effect of different distributions. For new location likelihood, how significant the max value is will be evaluated.