### PR TITLE
Switch the octomap dependency to the system version.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend>libpointmatcher</depend> <!-- optional but recommended if lidar is used, also not available on 32 bits system, but rtabmap can be built without it -->
   <!-- <depend>libproj-dev</depend> needed due to error in vtk6 (kinetic)-->
   <depend>libsqlite3-dev</depend>
-  <depend>octomap</depend>
+  <depend>liboctomap-dev</depend>
 <!--  <depend>grid_map_core</depend> # not available on Rolling -->
   <depend>qtbase5-dev</depend>
   <depend>zlib</depend>


### PR DESCRIPTION
We are shortly going to be removing octomap the package from ROS 2 Rolling; that's because it's ABI conflicts with the system package.  Instead, switch rtabmap to use the system package, which should work fine.

See https://github.com/ros/rosdistro/issues/41622 for more information.

Note that I targeted this at the `rolling-devel` branch, as that is what is listed in https://github.com/ros/rosdistro/blob/7a5a758b89acab0ce46632ca5ea6e9ba45d4c455/rolling/distribution.yaml#L6945-L6959 .  Let me know if you'd prefer something else.