### PR TITLE
fix build with ceres<2.1

### DIFF
--- a/corelib/src/optimizer/ceres/pose_graph_2d/angle_manifold.h
+++ b/corelib/src/optimizer/ceres/pose_graph_2d/angle_manifold.h
@@ -31,8 +31,13 @@
 #ifndef CERES_EXAMPLES_POSE_GRAPH_2D_ANGLE_MANIFOLD_H_
 #define CERES_EXAMPLES_POSE_GRAPH_2D_ANGLE_MANIFOLD_H_
 
-#include "ceres/autodiff_manifold.h"
-#include "ceres/manifold.h"
+#if CERES_VERSION_MAJOR >= 3 || \
+    (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1)
+#include <ceres/autodiff_manifold.h>
+#include <ceres/manifold.h>
+#else
+#include <ceres/local_parameterization.h>
+#endif
 #include "normalize_angle.h"
 
 namespace ceres {


### PR DESCRIPTION
Related to #1405
corelib/src/optimizer/ceres/pose_graph_3d/eigen_quaternion_parameterization.h is also not compatible. However this file is not used, so I left it as is.