### PR TITLE
fixed ORB_SLAM preproc breaking gui conditionals

### DIFF
--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -4892,10 +4892,13 @@ void PreferencesDialog::setParameter(const std::string & key, const std::string 
 				{
 					if(valueInt==2 && combo->objectName().toStdString().compare(Parameters::kOptimizerStrategy()) == 0)
 					{
+					if(
 #ifndef RTABMAP_ORB_SLAM
-						if(Optimizer::isAvailable(Optimizer::kTypeG2O))
+						Optimizer::isAvailable(Optimizer::kTypeG2O)
+#else
+						true
 #endif
-						{
+						){
 							UWARN("Trying to set \"%s\" to GTSAM but RTAB-Map isn't built "
 								"with GTSAM. Falling back to g2o.",
 								combo->objectName().toStdString().c_str());


### PR DESCRIPTION
setting RTABMAP_ORB_SLAM true would put the if statements all out of whack in the perferences dialog:

`/home/grover/vision_dev/rtabmap/guilib/src/PreferencesDialog.cpp: In member function ‘void rtabmap::PreferencesDialog::setParameter(const string&, const string&)’:
/home/grover/vision_dev/rtabmap/guilib/src/PreferencesDialog.cpp:4904:7: error: expected ‘}’ before ‘else’
 4904 |       else
      |       ^~~~
/home/grover/vision_dev/rtabmap/guilib/src/PreferencesDialog.cpp:4894:6: note: to match this ‘{’
 4894 |      {
      |      ^
`

There may be a cleaner way to do it, but his fixed my build