### PR TITLE
Handle edge case when SuperPoint detects only 1 keypoint

### DIFF
--- a/corelib/src/superpoint_torch/SuperPoint.cc
+++ b/corelib/src/superpoint_torch/SuperPoint.cc
@@ -242,7 +242,7 @@ cv::Mat SPDetector::compute(const std::vector<cv::KeyPoint> &keypoints)
 		auto desc = torch::grid_sampler(desc_, grid, 0, 0, true);  // [1, 256, 1, n_keypoints]
 
 		// normalize to 1
-		desc = torch::nn::functional::normalize(desc.reshape({desc_.size(1), keypoints.size()})); // [256, n_keypoints]
+		desc = torch::nn::functional::normalize(desc.reshape({desc_.size(1), -1}), torch::nn::functional::NormalizeFuncOptions().dim(0)); //[256, n_keypoints]
 		desc = desc.transpose(0, 1).contiguous(); //[n_keypoints, 256]
 
 		if(cuda_)

--- a/corelib/src/superpoint_torch/SuperPoint.cc
+++ b/corelib/src/superpoint_torch/SuperPoint.cc
@@ -242,8 +242,7 @@ cv::Mat SPDetector::compute(const std::vector<cv::KeyPoint> &keypoints)
 		auto desc = torch::grid_sampler(desc_, grid, 0, 0, true);  // [1, 256, 1, n_keypoints]
 
 		// normalize to 1
-		desc = torch::nn::functional::normalize(desc.reshape({1, desc_.size(1), -1})); //[1, 256, n_keypoints]
-		desc = desc.squeeze(); //[256, n_keypoints]
+		desc = torch::nn::functional::normalize(desc.reshape({desc_.size(1), keypoints.size()})); // [256, n_keypoints]
 		desc = desc.transpose(0, 1).contiguous(); //[n_keypoints, 256]
 
 		if(cuda_)


### PR DESCRIPTION
Fixes #1505. When SuperPoint detects exactly 1 feature for a photo, dimensions are collapsed and the application crashes  during the transpose operation at line 247.