### PR TITLE
Minor correction on using tilted sensor model for OAK camera

### DIFF
--- a/corelib/src/camera/CameraDepthAI.cpp
+++ b/corelib/src/camera/CameraDepthAI.cpp
@@ -371,7 +371,7 @@ bool CameraDepthAI::init(const std::string & calibrationFolder, const std::strin
 
 	std::vector<float> coeffs = calibHandler.getDistortionCoefficients(cameraId);
 	if(calibHandler.getDistortionModel(cameraId) == dai::CameraModel::Perspective)
-		distCoeffs = (cv::Mat_<double>(1,8) << coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4], coeffs[5], coeffs[6], coeffs[7]);
+		distCoeffs = (cv::Mat_<double>(1,14) << coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4], coeffs[5], coeffs[6], coeffs[7], coeffs[8], coeffs[9], coeffs[10], coeffs[11], coeffs[12], coeffs[13]);
 
 	if(alphaScaling_>-1.0f)
 		newCameraMatrix = cv::getOptimalNewCameraMatrix(cameraMatrix, distCoeffs, targetSize_, alphaScaling_);


### PR DESCRIPTION
OAK cameras released after the end of 2024 use a tilted sensor model during factory calibration. That is, the two additional parameters tauX and tauY are enabled. So we now need to use intrinsic with 14 parameters instead of 8. This will slightly change the result of cv::getOptimalNewCameraMatrix() and theoretically also slightly improve SLAM accuracy.
https://docs.luxonis.com/hardware/platform/depth/calibration/#About%20Camera%20Calibration-Distortion%20Models

We found that the OAK camera also had other accuracy issues, and it always overestimated the distance to distant objects. The explanation their team gave me was that due to the nonlinear nature of disparity estimation, even if the cameras are perfectly calibrated and rectified, the depth estimation will be biased. This analysis is correct, but we find that the existing bias still exceeds the range given by this explanation. There may be other problems in its internal SGBM implementation, which we will study in the near future.