### PR TITLE
Cleanup OccupancyGrid's cellCount_ unused member (#1639)

### DIFF
--- a/corelib/include/rtabmap/core/global_map/OccupancyGrid.h
+++ b/corelib/include/rtabmap/core/global_map/OccupancyGrid.h
@@ -57,7 +57,6 @@ protected:
 private:
 	cv::Mat map_;
 	cv::Mat mapInfo_;
-	std::map<int, std::pair<int, int> > cellCount_; //<node Id, cells>
 
 	float minMapSize_;
 	bool erode_;


### PR DESCRIPTION
Originally used here:
https://github.com/introlab/rtabmap/blob/a406c3775099f351eec9474a5432e9356ce53e95/corelib/src/OccupancyGrid.cpp#L866-L886

but incremental approach was removed in that refactoring: https://github.com/introlab/rtabmap/commit/71415992acc8d44e3b3dea2b992013a3022b480c

* Significant processing boost: from ~44 ms to ~24 ms to assemble 800 local grids.