### PR TITLE
fix another typo for ceres optimizer

### DIFF
--- a/corelib/src/optimizer/ceres/pose_graph_2d/angle_manifold.h
+++ b/corelib/src/optimizer/ceres/pose_graph_2d/angle_manifold.h
@@ -77,7 +77,7 @@ class AngleManifold {
 
 #else
 
-class AngleManfold {
+class AngleManifold {
  public:
 
   template <typename T>
@@ -90,7 +90,7 @@ class AngleManfold {
   }
 
   static ceres::LocalParameterization* Create() {
-    return (new ceres::AutoDiffLocalParameterization<AngleManfold, 1, 1>);
+    return (new ceres::AutoDiffLocalParameterization<AngleManifold, 1, 1>);
   }
 };
 


### PR DESCRIPTION
After enabling Ceres, the compilation failed, and I found that #1544 only fixed half of the typo:>