### PR TITLE
Enable WITH_PYTHON on CI

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
-        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev ${{ matrix.extra_deps }}
+        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev pybind11-dev libpython3-dev ${{ matrix.extra_deps }}
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -27,15 +27,15 @@ jobs:
         - build_name: ubuntu-22.04
           os: ubuntu-22.04
           extra_deps: "libunwind-dev libceres-dev"
-          extra_cmake_def: "-DWITH_CERES=ON"
+          extra_cmake_def: "-DWITH_CERES=ON -DWITH_PYTHON=ON"
         - build_name: ubuntu-24.04
           os: ubuntu-24.04
           extra_deps: "libg2o-dev libceres-dev"
-          extra_cmake_def: "-DWITH_CERES=ON"
+          extra_cmake_def: "-DWITH_CERES=ON -DWITH_PYTHON=ON"
         - build_name: ubuntu-24.04-with-opengv
           os: ubuntu-24.04
           extra_deps: "libg2o-dev libceres-dev"
-          extra_cmake_def: "-DWITH_CERES=ON -DBUILD_OPENGV=ON"
+          extra_cmake_def: "-DWITH_CERES=ON -DWITH_PYTHON=ON -DBUILD_OPENGV=ON"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,11 +44,21 @@ jobs:
       run: |
         DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
-        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev pybind11-dev python3-dev ${{ matrix.extra_deps }}
+        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev ${{ matrix.extra_deps }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    - name: Install Python Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy pybind11
 
     - name: Configure CMake
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{ matrix.extra_cmake_def }}
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPython3_EXECUTABLE=$(which python) ${{ matrix.extra_cmake_def }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
-        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev pybind11-dev ${{ matrix.extra_deps }}
+        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev ${{ matrix.extra_deps }}
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -54,7 +54,7 @@ jobs:
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy
+        pip install numpy pybind11
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
-        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev ${{ matrix.extra_deps }}
+        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev pybind11-dev ${{ matrix.extra_deps }}
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -54,7 +54,7 @@ jobs:
     - name: Install Python Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy pybind11
+        pip install numpy
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Configure CMake
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPython3_EXECUTABLE=$(which python) ${{ matrix.extra_cmake_def }}
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPython3_EXECUTABLE=$(which python3) -Dpybind11_DIR=$(python3 -m pybind11 --cmakedir) ${{ matrix.extra_cmake_def }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         DEBIAN_FRONTEND=noninteractive
         sudo apt-get update
-        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev pybind11-dev libpython3-dev ${{ matrix.extra_deps }}
+        sudo apt-get -y install libopencv-dev libpcl-dev git cmake software-properties-common libyaml-cpp-dev pybind11-dev python3-dev ${{ matrix.extra_deps }}
 
     - name: Configure CMake
       run: |

--- a/corelib/src/python/PythonInterface.cpp
+++ b/corelib/src/python/PythonInterface.cpp
@@ -19,9 +19,11 @@ PythonInterface::PythonInterface()
 	guard_ = new pybind11::scoped_interpreter();
 
 	// Tell Python to look in this directory for DLLs
+#ifdef _WIN32
 	std::string exe_dir = std::filesystem::current_path().string();
     pybind11::module_ os = pybind11::module_::import("os");
     os.attr("add_dll_directory")(exe_dir);
+#endif
 
 	pybind11::module::import("threading");
 	release_ = new pybind11::gil_scoped_release();

--- a/guilib/src/ui/preferencesDialog.ui
+++ b/guilib/src/ui/preferencesDialog.ui
@@ -23649,7 +23649,7 @@ Lower the ratio -&gt; higher the precision.</string>
                             </widget>
                            </item>
                            <item row="2" column="1">
-                            <spacer name="verticalSpacer_93">
+                            <spacer name="verticalSpacer_931">
                              <property name="orientation">
                               <enum>Qt::Vertical</enum>
                              </property>


### PR DESCRIPTION
On older machines, `pybind11::module_` doesn't exist, which was `pybind11::module`. That code was specific to windows (for the recent windows ci refactor), so I am adding a `#ifdef _WIN32` instead of making it backward compatible.
```
~/workspace/rtabmap/corelib/src/python/PythonInterface.cpp: In constructor ‘rtabmap::PythonInterface::PythonInterface()’:
~/workspace/rtabmap/corelib/src/python/PythonInterface.cpp:23:15: error: ‘module_’ is not a member of ‘pybind11’; did you mean ‘module’?
   23 |     pybind11::module_ os = pybind11::module_::import("os");
      |               ^~~~~~~
      |               module
~/workspace/rtabmap/corelib/src/python/PythonInterface.cpp:24:5: error: ‘os’ was not declared in this scope; did you mean ‘cos’?
   24 |     os.attr("add_dll_directory")(exe_dir);
      |     ^~
      |     cos
```