### PR TITLE
Preserve the attributes of intermediate nodes when retrieving data from the database

### DIFF
--- a/corelib/src/DBReader.cpp
+++ b/corelib/src/DBReader.cpp
@@ -749,7 +749,7 @@ SensorData DBReader::getNextData(SensorCaptureInfo * info)
 					data.setStereoCameraModels(combinedStereoModels);
 				}
 			}
-			data.setId(seq);
+			data.setId(s->getWeight()==-1 ? -1 : seq);
 			data.setStamp(s->getStamp());
 			data.setGroundTruth(s->getGroundTruthPose());
 			if(!globalPose.isNull())


### PR DESCRIPTION
When we reprocess a database containing intermediate nodes, the intermediate nodes are treated as normal nodes. This presents some problems because intermediate nodes typically do not contain data, or only contain sensor data without a signature. After checking, I found that it seems only this one line of fix is ​​needed.