### PR TITLE
Fixed empty global map on ros (regression from #1698)

### DIFF
--- a/corelib/include/rtabmap/core/Memory.h
+++ b/corelib/include/rtabmap/core/Memory.h
@@ -144,7 +144,7 @@ public:
 	void deleteLocation(int locationId, std::list<int> * deletedWords = 0);
 	void saveLocationData(int locationId);
 	void removeLink(int idA, int idB);
-	void removeRawData(int id, bool image = true, bool scan = true, bool userData = true);
+	void removeRawData(int id, bool image = true, bool scan = true, bool userData = true, bool occupancyGrid = true);
 	int reduceNode(int id, float maxDistance = 0.0f, bool keepLinkedInDb = false, int direction = 0);
 
 	//getters

--- a/corelib/src/Memory.cpp
+++ b/corelib/src/Memory.cpp
@@ -3176,7 +3176,7 @@ void Memory::removeLink(int oldId, int newId)
 	}
 }
 
-void Memory::removeRawData(int id, bool image, bool scan, bool userData)
+void Memory::removeRawData(int id, bool image, bool scan, bool userData, bool occupancyGrid)
 {
 	UDEBUG("id=%d image=%d scan=%d userData=%d", id, image?1:0, scan?1:0, userData?1:0);
 	Signature * s = this->_getSignature(id);
@@ -3185,7 +3185,8 @@ void Memory::removeRawData(int id, bool image, bool scan, bool userData)
 		s->sensorData().clearRawData(
 				image && (!_reextractLoopClosureFeatures || !_registrationPipeline->isImageRequired()),
 				scan && !_registrationPipeline->isScanRequired(),
-				userData && !_registrationPipeline->isUserDataRequired());
+				userData && !_registrationPipeline->isUserDataRequired(),
+				occupancyGrid);
 	}
 }
 

--- a/corelib/src/Rtabmap.cpp
+++ b/corelib/src/Rtabmap.cpp
@@ -4423,7 +4423,7 @@ bool Rtabmap::process(
 	}
 	if(!_rawDataKept)
 	{
-		_memory->removeRawData(signature->id(), true, !_neighborLinkRefining && !_proximityBySpace, true);
+		_memory->removeRawData(signature->id(), true, !_neighborLinkRefining && !_proximityBySpace, true, false);
 	}
 
 	// Localization mode and saving localization data: save odometry covariance in a prior link

--- a/corelib/src/SensorData.cpp
+++ b/corelib/src/SensorData.cpp
@@ -997,6 +997,14 @@ void SensorData::clearCompressedData(bool images, bool scan, bool userData, bool
 		_groundCellsCompressed=cv::Mat();
 		_emptyCellsCompressed=cv::Mat();
 		_obstacleCellsCompressed=cv::Mat();
+		
+		if( _groundCellsCompressed.empty()  && _groundCellsRaw.empty() &&
+			_obstacleCellsCompressed.empty()  && _obstacleCellsRaw.empty() &&
+			_emptyCellsCompressed.empty()  && _emptyCellsRaw.empty())
+		{
+			_cellSize = 0.0f;
+			_viewPoint = cv::Point3f();
+		}
 	}
 }
 void SensorData::clearRawData(bool images, bool scan, bool userData, bool occupancyGrid)
@@ -1024,6 +1032,14 @@ void SensorData::clearRawData(bool images, bool scan, bool userData, bool occupa
 		_groundCellsRaw=cv::Mat();
 		_emptyCellsRaw=cv::Mat();
 		_obstacleCellsRaw=cv::Mat();
+
+		if( _groundCellsCompressed.empty()  && _groundCellsRaw.empty() &&
+			_obstacleCellsCompressed.empty()  && _obstacleCellsRaw.empty() &&
+			_emptyCellsCompressed.empty()  && _emptyCellsRaw.empty())
+		{
+			_cellSize = 0.0f;
+			_viewPoint = cv::Point3f();
+		}
 	}
 }
 


### PR DESCRIPTION
With the refactor of `SensorData` in #1698 about how/when occupancy grids are removed, we didn't reset grid cell size to 0 when both compressed and raw occupancy grids were removed. On ROS side, we called `Memory::getNodeData` to get the occupancy grid, but in that function we only reload occupancy grids from database if grid cell size is 0. 