### PR TITLE
Fixed backward compatibility with bionic (Qt::ItemFlags)

### DIFF
--- a/corelib/src/Rtabmap.cpp
+++ b/corelib/src/Rtabmap.cpp
@@ -4418,7 +4418,7 @@ bool Rtabmap::process(
 	}
 	if(!_publishLastSignatureData)
 	{
-		lastSignatureData.sensorData().clearCompressedData();
+		lastSignatureData.sensorData().clearCompressedData(true, true, true, false);
 		lastSignatureData.sensorData().clearRawData();
 	}
 	if(!_rawDataKept)

--- a/guilib/src/PreferencesDialog.cpp
+++ b/guilib/src/PreferencesDialog.cpp
@@ -5607,7 +5607,7 @@ void PreferencesDialog::updateGlobalDescriptorVisibility()
 
 void PreferencesDialog::updateAvailableMarkerDictionaries()
 {
-	Qt::ItemFlags enableFlags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+	Qt::ItemFlags enableFlags = Qt::ItemFlags(Qt::ItemIsEnabled) | Qt::ItemIsSelectable;
 	for(int i=0;i<_ui->MarkerDictionary->count();++i) {
 		_ui->MarkerDictionary->setItemData(i, QVariant(static_cast<int>(enableFlags)), Qt::UserRole - 1); 
 	}


### PR DESCRIPTION
Side fix: don't clear compressed occupancy grid when `Rtabmap/PublishLastSignature` is false (old behavior)