### PR TITLE
rtabmap-info: fixing empty parameter strings showing of as NA

### DIFF
--- a/corelib/src/Parameters.cpp
+++ b/corelib/src/Parameters.cpp
@@ -113,11 +113,14 @@ ParametersMap Parameters::deserialize(const std::string & parameters)
 	std::list<std::string> tuplets = uSplit(parameters, ';');
 	for(std::list<std::string>::iterator iter=tuplets.begin(); iter!=tuplets.end(); ++iter)
 	{
-		std::list<std::string> p = uSplit(*iter, ':');
-		if(p.size() == 2)
+		// Split on the FIRST ':' only. Using uSplit() here would discard
+		// empty tokens, so a tuplet like "Marker/Lengths:" (legitimate empty
+		// string value) would lose the value side and be dropped entirely.
+		size_t colonPos = iter->find(':');
+		if(colonPos != std::string::npos && colonPos > 0)
 		{
-			std::string key = p.front();
-			std::string value = p.back();
+			std::string key = iter->substr(0, colonPos);
+			std::string value = iter->substr(colonPos + 1);
 
 			// look for old parameter name
 			bool addParameter = true;

--- a/tools/Info/main.cpp
+++ b/tools/Info/main.cpp
@@ -153,8 +153,14 @@ int main(int argc, char * argv[])
 #endif
 	int padding = 35;
 	std::cout << ("Parameters (Yellow=modified, Red=old parameter not used anymore, NA=not in database):\n");
-	auto displayValue = [](const std::string & v) -> std::string {
-		return v.empty() ? std::string("\"\"") : v;
+	auto displayValue = [](const std::string & key, const std::string & v) -> std::string {
+		// Quote string-typed parameters so empty values are visible and
+		// whitespace-padded values aren't misread as missing.
+		if(Parameters::getType(key) == "string")
+		{
+			return std::string("\"") + v + "\"";
+		}
+		return v;
 	};
 	for(ParametersMap::iterator iter=parameters.begin(); iter!=parameters.end(); ++iter)
 	{
@@ -198,7 +204,7 @@ int main(int argc, char * argv[])
 #else
 				printf("%s", COLOR_YELLOW);
 #endif
-				std::cout << (uFormat("%s%s  (%s=%s)\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str(), displayValue(defaultValue).c_str()));
+				std::cout << (uFormat("%s%s  (%s=%s)\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->first, iter->second).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str(), displayValue(iter->first, defaultValue).c_str()));
 			}
 			else if(!diff)
 			{
@@ -208,7 +214,7 @@ int main(int argc, char * argv[])
 #else
 				printf("%s", COLOR_NORMAL);
 #endif
-				std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str()));
+				std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->first, iter->second).c_str()));
 			}
 		}
 		else if(!defaultValueSet)
@@ -219,7 +225,7 @@ int main(int argc, char * argv[])
 #else
 			printf("%s", COLOR_RED);
 #endif
-			std::cout << (uFormat("%s%s  (%s=NA)\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str()));
+			std::cout << (uFormat("%s%s  (%s=NA)\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->first, iter->second).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str()));
 		}
 		else if(!diff)
 		{
@@ -229,7 +235,7 @@ int main(int argc, char * argv[])
 #else
 			printf("%s", COLOR_NORMAL);
 #endif
-			std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str()));
+			std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->first, iter->second).c_str()));
 		}
 #ifdef _WIN32
 		SetConsoleTextAttribute(H,COLOR_NORMAL);
@@ -249,7 +255,7 @@ int main(int argc, char * argv[])
 #else
 			printf("%s", COLOR_RED);
 #endif
-			std::cout << (uFormat("%sNA  (%s=\"%s\")\n", uPad(iter->first + "=", padding).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str(), iter->second.c_str()));
+			std::cout << (uFormat("%sNA  (%s=%s)\n", uPad(iter->first + "=", padding).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str(), displayValue(iter->first, iter->second).c_str()));
 		
 #ifdef _WIN32
 			SetConsoleTextAttribute(H,COLOR_NORMAL);

--- a/tools/Info/main.cpp
+++ b/tools/Info/main.cpp
@@ -153,6 +153,9 @@ int main(int argc, char * argv[])
 #endif
 	int padding = 35;
 	std::cout << ("Parameters (Yellow=modified, Red=old parameter not used anymore, NA=not in database):\n");
+	auto displayValue = [](const std::string & v) -> std::string {
+		return v.empty() ? std::string("\"\"") : v;
+	};
 	for(ParametersMap::iterator iter=parameters.begin(); iter!=parameters.end(); ++iter)
 	{
 		ParametersMap::const_iterator jter = defaultParameters.find(iter->first);
@@ -195,7 +198,7 @@ int main(int argc, char * argv[])
 #else
 				printf("%s", COLOR_YELLOW);
 #endif
-				std::cout << (uFormat("%s%s  (%s=%s)\n", uPad(iter->first + "=", padding).c_str(), iter->second.c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str(), defaultValue.c_str()));
+				std::cout << (uFormat("%s%s  (%s=%s)\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str(), displayValue(defaultValue).c_str()));
 			}
 			else if(!diff)
 			{
@@ -205,7 +208,7 @@ int main(int argc, char * argv[])
 #else
 				printf("%s", COLOR_NORMAL);
 #endif
-				std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), iter->second.c_str()));
+				std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str()));
 			}
 		}
 		else if(!defaultValueSet)
@@ -216,7 +219,7 @@ int main(int argc, char * argv[])
 #else
 			printf("%s", COLOR_RED);
 #endif
-			std::cout << (uFormat("%s%s  (%s=NA)\n", uPad(iter->first + "=", padding).c_str(), iter->second.c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str()));
+			std::cout << (uFormat("%s%s  (%s=NA)\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str(), otherDatabasePath.empty()?"default":otherDatabasePathName.c_str()));
 		}
 		else if(!diff)
 		{
@@ -226,7 +229,7 @@ int main(int argc, char * argv[])
 #else
 			printf("%s", COLOR_NORMAL);
 #endif
-			std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), iter->second.c_str()));
+			std::cout << (uFormat("%s%s\n", uPad(iter->first + "=", padding).c_str(), displayValue(iter->second).c_str()));
 		}
 #ifdef _WIN32
 		SetConsoleTextAttribute(H,COLOR_NORMAL);


### PR DESCRIPTION
Issue:
```
rtabmap-info rtabmap.db
...
Db/TargetVersion=                  NA  (default="")
Icp/DebugExportFormat=             NA  (default="")
Icp/PMConfig=                      NA  (default="")
Kp/DictionaryPath=                 NA  (default="")
Marker/Lengths=                    NA  (default="")
Marker/Priors=                     NA  (default="")
OdomLIOSAM/ConfigPath=             NA  (default="")
OdomOKVIS/ConfigPath=              NA  (default="")
OdomORBSLAM/VocPath=               NA  (default="")
OdomOpenVINS/LeftMaskPath=         NA  (default="")
OdomOpenVINS/RightMaskPath=        NA  (default="")
OdomVINSFusion/ConfigPath=         NA  (default="")
PyDescriptor/Path=                 NA  (default="")
PyMatcher/Path=                    NA  (default="")
Rtabmap/WorkingDirectory=          NA  (default="")
SuperPoint/ModelPath=              NA  (default="")
```