### PR TITLE
Add OpenCV 5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,14 @@ option(BUILD_WITH_RPATH_NOT_RUNPATH "Explicitly disable usage of RUNPATH for the
 set(RTABMAP_QT_VERSION AUTO CACHE STRING "Force a specific Qt version.")
 set_property(CACHE RTABMAP_QT_VERSION PROPERTY STRINGS AUTO 4 5 6)
 
-FIND_PACKAGE(OpenCV REQUIRED QUIET COMPONENTS core calib3d imgproc highgui stitching photo video videoio OPTIONAL_COMPONENTS aruco objdetect xfeatures2d nonfree gpu cudafeatures2d cudaoptflow cudaimgproc)
+# OpenCV 5 split calib3d into calib/geometry/stereo and renamed features2d to features.
+FIND_PACKAGE(OpenCV REQUIRED QUIET)
+IF(OpenCV_VERSION VERSION_LESS "5.0.0")
+  SET(RTABMAP_OPENCV_CALIB3D calib3d)
+ELSE()
+  SET(RTABMAP_OPENCV_CALIB3D calib geometry stereo features)
+ENDIF()
+FIND_PACKAGE(OpenCV REQUIRED QUIET COMPONENTS core ${RTABMAP_OPENCV_CALIB3D} imgproc highgui stitching photo video videoio OPTIONAL_COMPONENTS aruco objdetect xfeatures2d nonfree gpu cudafeatures2d cudaoptflow cudaimgproc)
 
 IF(WITH_QT)
 FIND_PACKAGE(PCL 1.7 REQUIRED QUIET COMPONENTS common io kdtree search surface filters registration sample_consensus segmentation visualization)

--- a/RTABMapConfig.cmake.in
+++ b/RTABMapConfig.cmake.in
@@ -1,7 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 # Mandatory dependencies
-find_dependency(OpenCV COMPONENTS core calib3d imgproc highgui stitching photo video OPTIONAL_COMPONENTS aruco objdetect xfeatures2d nonfree gpu cudafeatures2d)
+find_dependency(OpenCV COMPONENTS core @RTABMAP_OPENCV_CALIB3D@ imgproc highgui stitching photo video OPTIONAL_COMPONENTS aruco objdetect xfeatures2d nonfree gpu cudafeatures2d)
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/RTABMap_guiTargets.cmake")
     find_dependency(PCL 1.7 COMPONENTS common io kdtree search surface filters registration sample_consensus segmentation visualization)

--- a/corelib/include/rtabmap/core/DBDriverSqlite3.h
+++ b/corelib/include/rtabmap/core/DBDriverSqlite3.h
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "rtabmap/core/rtabmap_core_export.h" // DLL export/import defines
 #include "rtabmap/core/DBDriver.h"
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 
 typedef struct sqlite3_stmt sqlite3_stmt;
 typedef struct sqlite3 sqlite3;

--- a/corelib/include/rtabmap/core/EpipolarGeometry.h
+++ b/corelib/include/rtabmap/core/EpipolarGeometry.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/core/Parameters.h"
 #include "rtabmap/utilite/UStl.h"
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <list>

--- a/corelib/include/rtabmap/core/Features2d.h
+++ b/corelib/include/rtabmap/core/Features2d.h
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <list>
 #include <numeric>
 #include "rtabmap/core/Parameters.h"
@@ -70,6 +70,10 @@ class BriefDescriptorExtractor;
 class SIFT;
 #endif
 class SURF;
+#if CV_MAJOR_VERSION >= 5
+class BRISK;
+class KAZE;
+#endif
 }
 namespace cuda {
 class FastFeatureDetector;
@@ -78,6 +82,13 @@ class SURF_CUDA;
 class CornersDetector;
 }
 }
+#if CV_MAJOR_VERSION >= 5
+// OpenCV 5 moved BRISK/KAZE from the core module to xfeatures2d (contrib).
+namespace cv {
+using xfeatures2d::BRISK;
+using xfeatures2d::KAZE;
+}
+#endif
 #if (CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION <= 3) || (CV_MAJOR_VERSION == 3 && (CV_MINOR_VERSION < 4 || (CV_MINOR_VERSION==4 && CV_SUBMINOR_VERSION<11)))
 typedef cv::xfeatures2d::SIFT CV_SIFT;
 #else

--- a/corelib/include/rtabmap/core/Memory.h
+++ b/corelib/include/rtabmap/core/Memory.h
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include "rtabmap/utilite/UStl.h"
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <pcl/pcl_config.h>
 
 namespace rtabmap {

--- a/corelib/include/rtabmap/core/OdometryInfo.h
+++ b/corelib/include/rtabmap/core/OdometryInfo.h
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/core/RegistrationInfo.h"
 #include "rtabmap/core/CameraModel.h"
 #include "rtabmap/core/LaserScan.h"
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 
 namespace rtabmap {
 

--- a/corelib/include/rtabmap/core/SensorData.h
+++ b/corelib/include/rtabmap/core/SensorData.h
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/StereoCameraModel.h>
 #include <rtabmap/core/Transform.h>
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <rtabmap/core/LaserScan.h>
 #include <rtabmap/core/IMU.h>
 #include <rtabmap/core/GPS.h>

--- a/corelib/include/rtabmap/core/Signature.h
+++ b/corelib/include/rtabmap/core/Signature.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <pcl/point_types.h>
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <map>
 #include <list>

--- a/corelib/include/rtabmap/core/Statistics.h
+++ b/corelib/include/rtabmap/core/Statistics.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/core/rtabmap_core_export.h" // DLL export/import defines
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <list>
 #include <vector>

--- a/corelib/include/rtabmap/core/VWDictionary.h
+++ b/corelib/include/rtabmap/core/VWDictionary.h
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <list>
 #include <set>
 #include "rtabmap/core/Parameters.h"

--- a/corelib/include/rtabmap/core/opencv2_compat.h
+++ b/corelib/include/rtabmap/core/opencv2_compat.h
@@ -1,0 +1,73 @@
+/*
+Backward-compatible OpenCV 5 shim for rtabmap.
+
+OpenCV 5 removed the legacy 1.x C API headers and the CV_ constant aliases they
+provided. This header keeps rtabmap's existing CV_ usage working on OpenCV 5
+without touching the OpenCV 2/3/4 code paths: on OpenCV < 5 it just pulls the
+legacy C API headers, on OpenCV >= 5 it maps the CV_ aliases used by rtabmap to
+their cv:: enum equivalents.
+*/
+#ifndef RTABMAP_CORE_OPENCV2_COMPAT_H_
+#define RTABMAP_CORE_OPENCV2_COMPAT_H_
+
+#include <opencv2/core/version.hpp>
+
+#if CV_MAJOR_VERSION < 5
+#include <opencv2/core/core_c.h>
+#include <opencv2/imgproc/types_c.h>
+#include <opencv2/imgproc/imgproc_c.h>
+#include <opencv2/highgui/highgui_c.h>
+#include <opencv2/calib3d/calib3d_c.h>
+#if CV_MAJOR_VERSION >= 3
+#include <opencv2/videoio/videoio_c.h> // videoio module only exists since OpenCV 3
+#endif
+#else
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/highgui.hpp>
+
+// Color conversions
+#define CV_BGR2GRAY cv::COLOR_BGR2GRAY
+#define CV_RGB2GRAY cv::COLOR_RGB2GRAY
+#define CV_GRAY2BGR cv::COLOR_GRAY2BGR
+#define CV_BGR2YCrCb cv::COLOR_BGR2YCrCb
+#define CV_YCrCb2BGR cv::COLOR_YCrCb2BGR
+#define CV_RGB2BGR cv::COLOR_RGB2BGR
+#define CV_BGRA2BGR cv::COLOR_BGRA2BGR
+#define CV_BGRA2GRAY cv::COLOR_BGRA2GRAY
+#define CV_RGBA2BGR cv::COLOR_RGBA2BGR
+#define CV_RGBA2GRAY cv::COLOR_RGBA2GRAY
+#define CV_RGBA2RGB cv::COLOR_RGBA2RGB
+#define CV_BayerBG2BGR cv::COLOR_BayerBG2BGR
+#define CV_BayerRG2BGR cv::COLOR_BayerRG2BGR
+#define CV_BayerRG2GRAY cv::COLOR_BayerRG2GRAY
+
+// VideoCapture properties
+#define CV_CAP_PROP_FRAME_WIDTH cv::CAP_PROP_FRAME_WIDTH
+#define CV_CAP_PROP_FRAME_HEIGHT cv::CAP_PROP_FRAME_HEIGHT
+#define CV_CAP_PROP_FPS cv::CAP_PROP_FPS
+#define CV_CAP_PROP_FOURCC cv::CAP_PROP_FOURCC
+#define CV_CAP_PROP_GUID cv::CAP_PROP_GUID
+#define CV_CAP_PROP_CONVERT_RGB cv::CAP_PROP_CONVERT_RGB
+
+// Chessboard detection flags
+#define CV_CALIB_CB_ADAPTIVE_THRESH cv::CALIB_CB_ADAPTIVE_THRESH
+#define CV_CALIB_CB_NORMALIZE_IMAGE cv::CALIB_CB_NORMALIZE_IMAGE
+
+// solvePnP methods
+#define CV_ITERATIVE cv::SOLVEPNP_ITERATIVE
+#define CV_EPNP cv::SOLVEPNP_EPNP
+#define CV_P3P cv::SOLVEPNP_P3P
+
+// Misc
+#define CV_TERMCRIT_ITER cv::TermCriteria::MAX_ITER
+#define CV_TERMCRIT_EPS cv::TermCriteria::EPS
+#define CV_INTER_CUBIC cv::INTER_CUBIC
+#define CV_WINDOW_AUTOSIZE cv::WINDOW_AUTOSIZE
+#define CV_SORT_DESCENDING cv::SORT_DESCENDING
+#define CV_PCA_DATA_AS_ROW cv::PCA::DATA_AS_ROW
+#define CV_L2 cv::NORM_L2
+#endif
+
+#endif // RTABMAP_CORE_OPENCV2_COMPAT_H_

--- a/corelib/include/rtabmap/core/stereo/stereoRectifyFisheye.h
+++ b/corelib/include/rtabmap/core/stereo/stereoRectifyFisheye.h
@@ -32,12 +32,115 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef CORELIB_SRC_OPENCV_STEREORECTIFYFISHEYE_H_
 #define CORELIB_SRC_OPENCV_STEREORECTIFYFISHEYE_H_
 
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #if CV_MAJOR_VERSION >= 3
+#if CV_MAJOR_VERSION < 5
 #include <opencv2/calib3d/calib3d_c.h>
+#endif
 
 #if CV_MAJOR_VERSION >= 4
+#if CV_MAJOR_VERSION < 5
 #include <opencv2/core/core_c.h>
+#else
+// OpenCV 5 removed the legacy C API. Provide the minimal CvMat compatibility the
+// vendored code below relies on, backed by cv::Mat so numerical behavior is unchanged.
+struct CvMat
+{
+	int type;
+	int step;
+	int rows;
+	int cols;
+	union { uchar* ptr; short* s; int* i; float* fl; double* db; } data;
+	cv::Mat backing; // owns storage for cvCreateMat/cvCloneMat; empty for headers
+};
+typedef struct CvSize { int width, height; } CvSize;
+typedef struct CvPoint2D32f { float x, y; } CvPoint2D32f;
+typedef struct CvPoint2D64f { double x, y; } CvPoint2D64f;
+typedef struct CvPoint3D32f { float x, y, z; } CvPoint3D32f;
+typedef struct CvPoint3D64f { double x, y, z; } CvPoint3D64f;
+typedef struct CvScalar { double val[4]; } CvScalar;
+
+#define CV_IS_MAT(m) ((m) != NULL)
+#define CV_ARE_DEPTHS_EQ(m1, m2) (CV_MAT_DEPTH((m1)->type) == CV_MAT_DEPTH((m2)->type))
+#define CV_DEFAULT(val) = val
+#define CV_GEMM_B_T 2
+#define CV_L2 cv::NORM_L2
+#define CV_StsBadArg cv::Error::StsBadArg
+#define CV_StsBadSize cv::Error::StsBadSize
+#define CV_StsNullPtr cv::Error::StsNullPtr
+#define CV_StsUnmatchedFormats cv::Error::StsUnmatchedFormats
+#define CV_StsUnsupportedFormat cv::Error::StsUnsupportedFormat
+
+static inline CvSize cvSize(int w, int h) { CvSize s; s.width = w; s.height = h; return s; }
+static inline CvSize cvSize(const cv::Size& sz) { CvSize s; s.width = sz.width; s.height = sz.height; return s; }
+static inline CvPoint2D32f cvPoint2D32f(double x, double y) { CvPoint2D32f p; p.x = (float)x; p.y = (float)y; return p; }
+static inline CvPoint2D64f cvPoint2D64f(double x, double y) { CvPoint2D64f p; p.x = x; p.y = y; return p; }
+
+static inline cv::Mat cvMatView(const CvMat* m)
+{ return cv::Mat(m->rows, m->cols, CV_MAT_TYPE(m->type), m->data.ptr, (size_t)m->step); }
+namespace cv { static inline cv::Mat cvarrToMat(const ::CvMat* m) { return cvMatView(m); } }
+
+static inline CvMat cvMat(const cv::Mat& m)
+{
+	CvMat self;
+	self.type = m.type() | (m.isContinuous() ? CV_MAT_CONT_FLAG : 0);
+	self.rows = m.rows;
+	self.cols = m.cols;
+	self.step = (int)m.step;
+	self.data.ptr = m.data;
+	return self;
+}
+static inline CvMat cvMat(int rows, int cols, int type, void* data = NULL)
+{
+	CvMat self;
+	self.type = CV_MAT_TYPE(type) | CV_MAT_CONT_FLAG;
+	self.rows = rows;
+	self.cols = cols;
+	self.step = cols * (int)CV_ELEM_SIZE(type);
+	self.data.ptr = (uchar*)data;
+	return self;
+}
+static inline CvMat* cvCreateMat(int rows, int cols, int type)
+{
+	CvMat* m = new CvMat();
+	m->backing = cv::Mat(rows, cols, CV_MAT_TYPE(type));
+	m->type = CV_MAT_TYPE(type) | CV_MAT_CONT_FLAG;
+	m->rows = rows;
+	m->cols = cols;
+	m->step = (int)m->backing.step;
+	m->data.ptr = m->backing.data;
+	return m;
+}
+static inline CvMat* cvCloneMat(const CvMat* src)
+{
+	CvMat* m = cvCreateMat(src->rows, src->cols, CV_MAT_TYPE(src->type));
+	cvMatView(src).copyTo(m->backing);
+	return m;
+}
+static inline void cvReleaseMat(CvMat** m) { if (m && *m) { delete *m; *m = NULL; } }
+static inline void cvZero(CvMat* m) { cv::Mat d = cvMatView(m); d.setTo(cv::Scalar::all(0)); }
+static inline void cvCopy(const CvMat* src, CvMat* dst) { cv::Mat d = cvMatView(dst); cvMatView(src).copyTo(d); }
+static inline void cvConvert(const CvMat* src, CvMat* dst) { cv::Mat d = cvMatView(dst); cvMatView(src).convertTo(d, d.type()); }
+static inline void cvConvertScale(const CvMat* src, CvMat* dst, double scale, double shift = 0) { cv::Mat d = cvMatView(dst); cvMatView(src).convertTo(d, d.type(), scale, shift); }
+static inline void cvTranspose(const CvMat* src, CvMat* dst) { cv::Mat d = cvMatView(dst); cv::transpose(cvMatView(src), d); }
+static inline void cvGEMM(const CvMat* A, const CvMat* B, double alpha, const CvMat* C, double beta, CvMat* D, int flags = 0) { cv::Mat d = cvMatView(D); cv::gemm(cvMatView(A), cvMatView(B), alpha, C ? cvMatView(C) : cv::Mat(), beta, d, flags); }
+static inline void cvMatMul(const CvMat* A, const CvMat* B, CvMat* D) { cvGEMM(A, B, 1, 0, 0, D, 0); }
+static inline void cvSetIdentity(CvMat* m, double value = 1) { cv::Mat d = cvMatView(m); cv::setIdentity(d, cv::Scalar::all(value)); }
+static inline double cvNorm(const CvMat* A, const CvMat* B, int normType) { return B ? cv::norm(cvMatView(A), cvMatView(B), normType) : cv::norm(cvMatView(A), normType); }
+static inline CvScalar cvAvg(const CvMat* m) { cv::Scalar s = cv::mean(cvMatView(m)); CvScalar r; for (int i = 0; i < 4; ++i) r.val[i] = s[i]; return r; }
+static inline double cvmGet(const CvMat* m, int row, int col) { return ((const double*)((const uchar*)m->data.ptr + (size_t)m->step * row))[col]; }
+static inline void cvmSet(CvMat* m, int row, int col, double val) { ((double*)((uchar*)m->data.ptr + (size_t)m->step * row))[col] = val; }
+static inline double cvVecElem(const CvMat* m, int k) { return m->rows == 1 ? ((const double*)m->data.ptr)[k] : *(const double*)((const uchar*)m->data.ptr + (size_t)m->step * k); }
+static inline void cvSetVecElem(CvMat* m, int k, double v) { if (m->rows == 1) ((double*)m->data.ptr)[k] = v; else *(double*)((uchar*)m->data.ptr + (size_t)m->step * k) = v; }
+static inline void cvCrossProduct(const CvMat* a, const CvMat* b, CvMat* c)
+{
+	double a0 = cvVecElem(a, 0), a1 = cvVecElem(a, 1), a2 = cvVecElem(a, 2);
+	double b0 = cvVecElem(b, 0), b1 = cvVecElem(b, 1), b2 = cvVecElem(b, 2);
+	cvSetVecElem(c, 0, a1 * b2 - a2 * b1);
+	cvSetVecElem(c, 1, a2 * b0 - a0 * b2);
+	cvSetVecElem(c, 2, a0 * b1 - a1 * b0);
+}
+#endif
 
 // Opencv4 doesn't expose those functions below anymore, we should recopy all of them!
 int cvRodrigues2( const CvMat* src, CvMat* dst, CvMat* jacobian CV_DEFAULT(0))

--- a/corelib/include/rtabmap/core/util3d_correspondences.h
+++ b/corelib/include/rtabmap/core/util3d_correspondences.h
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <set>
 #include <map>
 #include <list>

--- a/corelib/include/rtabmap/core/util3d_features.h
+++ b/corelib/include/rtabmap/core/util3d_features.h
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap/core/rtabmap_core_export.h>
 
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <rtabmap/core/Transform.h>
 #include <rtabmap/core/CameraModel.h>
 #include <rtabmap/core/StereoCameraModel.h>

--- a/corelib/src/CameraModel.cpp
+++ b/corelib/src/CameraModel.cpp
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UConversion.h>
 #include <rtabmap/utilite/UMath.h>
 #include <rtabmap/utilite/UStl.h>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
 namespace rtabmap {

--- a/corelib/src/EpipolarGeometry.cpp
+++ b/corelib/src/EpipolarGeometry.cpp
@@ -33,8 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UMath.h"
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/core/core_c.h>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
+#include <rtabmap/core/opencv2_compat.h>
 #include <iostream>
 
 namespace rtabmap

--- a/corelib/src/Features2d.cpp
+++ b/corelib/src/Features2d.cpp
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UMath.h"
 #include "rtabmap/utilite/ULogger.h"
 #include "rtabmap/utilite/UTimer.h"
-#include <opencv2/imgproc/imgproc_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <opencv2/core/version.hpp>
 #include <opencv2/opencv_modules.hpp>
 

--- a/corelib/src/MarkerDetector.cpp
+++ b/corelib/src/MarkerDetector.cpp
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/util2d.h>
 #include <rtabmap/utilite/ULogger.h>
 #include <rtabmap/utilite/UStl.h>
+#include <opencv2/calib3d.hpp> // cv::Rodrigues (no longer pulled in transitively by aruco on OpenCV 5)
 
 #ifdef HAVE_OPENCV_ARUCO
 #if CV_MAJOR_VERSION < 4 || (CV_MAJOR_VERSION == 4 && CV_MINOR_VERSION <8)

--- a/corelib/src/Memory.cpp
+++ b/corelib/src/Memory.cpp
@@ -62,7 +62,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pcl/io/pcd_io.h>
 #include <pcl/common/common.h>
 #include <rtabmap/core/MarkerDetector.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <rtabmap/core/LocalGridMaker.h>
 
 namespace rtabmap {

--- a/corelib/src/RegistrationVis.cpp
+++ b/corelib/src/RegistrationVis.cpp
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UMath.h>
-#include <opencv2/core/core_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #if defined(HAVE_OPENCV_XFEATURES2D) && (CV_MAJOR_VERSION > 3 || (CV_MAJOR_VERSION==3 && CV_MINOR_VERSION >=4 && CV_SUBMINOR_VERSION >= 1))
 #include <opencv2/xfeatures2d.hpp> // For GMS matcher

--- a/corelib/src/SensorCaptureThread.cpp
+++ b/corelib/src/SensorCaptureThread.cpp
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/core/IMUFilter.h"
 #include "rtabmap/core/Features2d.h"
 #include "rtabmap/core/clams/discrete_depth_distortion_model.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <opencv2/stitching/detail/exposure_compensate.hpp>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/ULogger.h>

--- a/corelib/src/StereoCameraModel.cpp
+++ b/corelib/src/StereoCameraModel.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UDirectory.h>
 #include <rtabmap/utilite/UFile.h>
 #include <rtabmap/utilite/UConversion.h>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
 #if CV_MAJOR_VERSION > 2 or (CV_MAJOR_VERSION == 2 and (CV_MINOR_VERSION >4 or (CV_MINOR_VERSION == 4 and CV_SUBMINOR_VERSION >=10)))

--- a/corelib/src/camera/CameraFreenect.cpp
+++ b/corelib/src/camera/CameraFreenect.cpp
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UThread.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/core/util2d.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_FREENECT
 #include <libfreenect.h>

--- a/corelib/src/camera/CameraFreenect2.cpp
+++ b/corelib/src/camera/CameraFreenect2.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UMath.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/core/util2d.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_FREENECT2
 #include <libfreenect2/libfreenect2.hpp>

--- a/corelib/src/camera/CameraImages.cpp
+++ b/corelib/src/camera/CameraImages.cpp
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/util3d.h>
 #include <rtabmap/core/util3d_filtering.h>
 #include <rtabmap/core/Graph.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <fstream>
 
 namespace rtabmap

--- a/corelib/src/camera/CameraK4A.cpp
+++ b/corelib/src/camera/CameraK4A.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UThreadC.h>
 #include <rtabmap/core/util2d.h>
 #include <rtabmap/core/Compression.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_K4A
 #include <k4a/k4a.h>

--- a/corelib/src/camera/CameraK4W2.cpp
+++ b/corelib/src/camera/CameraK4W2.cpp
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UThreadC.h>
 #include <rtabmap/core/util2d.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_K4W2
 #include <Kinect.h>

--- a/corelib/src/camera/CameraOpenNI2.cpp
+++ b/corelib/src/camera/CameraOpenNI2.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UFile.h>
 #include <rtabmap/utilite/UThreadC.h>
 #include <rtabmap/core/util2d.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_OPENNI2
 #include <OniVersion.h>

--- a/corelib/src/camera/CameraOpenNICV.cpp
+++ b/corelib/src/camera/CameraOpenNICV.cpp
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/camera/CameraOpenNICV.h>
 #include <rtabmap/utilite/UTimer.h>
 #if CV_MAJOR_VERSION > 3
-#include <opencv2/videoio/videoio_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #endif
 
 namespace rtabmap
@@ -59,6 +59,7 @@ bool CameraOpenNICV::init(const std::string & calibrationFolder, const std::stri
 	}
 
 	ULOGGER_DEBUG("Camera::init()");
+#if CV_MAJOR_VERSION < 5
 	_capture.open( _asus?CV_CAP_OPENNI_ASUS:CV_CAP_OPENNI );
 	if(_capture.isOpened())
 	{
@@ -98,6 +99,10 @@ bool CameraOpenNICV::init(const std::string & calibrationFolder, const std::stri
 		return false;
 	}
 	return true;
+#else
+	UERROR("CameraOpenNICV requires OpenCV's OpenNI (v1) VideoCapture backend, which was removed in OpenCV 5. Use CameraOpenNI2 instead.");
+	return false;
+#endif
 }
 
 bool CameraOpenNICV::isCalibrated() const
@@ -112,8 +117,10 @@ SensorData CameraOpenNICV::captureImage(SensorCaptureInfo * info)
 	{
 		_capture.grab();
 		cv::Mat depth, rgb;
+#if CV_MAJOR_VERSION < 5
 		_capture.retrieve(depth, CV_CAP_OPENNI_DEPTH_MAP );
 		_capture.retrieve(rgb, CV_CAP_OPENNI_BGR_IMAGE );
+#endif
 
 		depth = depth.clone();
 		rgb = rgb.clone();

--- a/corelib/src/camera/CameraOpenni.cpp
+++ b/corelib/src/camera/CameraOpenni.cpp
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UFile.h>
 #include <rtabmap/utilite/UThreadC.h>
 #include <rtabmap/utilite/UTimer.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_OPENNI
 #include <pcl/io/openni_grabber.h>

--- a/corelib/src/camera/CameraRealSense.cpp
+++ b/corelib/src/camera/CameraRealSense.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UMath.h>
 #include <rtabmap/utilite/UThreadC.h>
 #include <rtabmap/core/util2d.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_REALSENSE
 #include <librealsense/rs.hpp>

--- a/corelib/src/camera/CameraRealSense2.cpp
+++ b/corelib/src/camera/CameraRealSense2.cpp
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UConversion.h>
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/utilite/UDirectory.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_REALSENSE2
 #include <librealsense2/rsutil.h>

--- a/corelib/src/camera/CameraStereoDC1394.cpp
+++ b/corelib/src/camera/CameraStereoDC1394.cpp
@@ -28,7 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/camera/CameraStereoDC1394.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UConversion.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_DC1394
 #include <dc1394/dc1394.h>

--- a/corelib/src/camera/CameraStereoFlyCapture2.cpp
+++ b/corelib/src/camera/CameraStereoFlyCapture2.cpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/camera/CameraStereoFlyCapture2.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UConversion.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_FLYCAPTURE2
 #include <triclopsrectify.h>

--- a/corelib/src/camera/CameraStereoImages.cpp
+++ b/corelib/src/camera/CameraStereoImages.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/utilite/UFile.h>
 #include <rtabmap/utilite/UConversion.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 namespace rtabmap
 {

--- a/corelib/src/camera/CameraStereoTara.cpp
+++ b/corelib/src/camera/CameraStereoTara.cpp
@@ -35,7 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UThreadC.h>
 #include <rtabmap/utilite/UConversion.h>
 #if CV_MAJOR_VERSION > 3
-#include <opencv2/videoio/videoio_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #endif
 
 namespace rtabmap

--- a/corelib/src/camera/CameraStereoVideo.cpp
+++ b/corelib/src/camera/CameraStereoVideo.cpp
@@ -28,13 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/camera/CameraStereoVideo.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UConversion.h>
-#include <opencv2/imgproc/types_c.h>
-#if CV_MAJOR_VERSION > 3
-#include <opencv2/videoio/videoio_c.h>
-#if CV_MAJOR_VERSION > 4
-#include <opencv2/videoio/legacy/constants_c.h>
-#endif
-#endif
+#include <rtabmap/core/opencv2_compat.h>
 
 namespace rtabmap
 {

--- a/corelib/src/camera/CameraStereoZedOC.cpp
+++ b/corelib/src/camera/CameraStereoZedOC.cpp
@@ -30,6 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UThread.h>
 #include <rtabmap/utilite/UEventsManager.h>
 #include <rtabmap/utilite/UConversion.h>
+#include <opencv2/calib3d.hpp>
 
 #ifdef RTABMAP_ZEDOC
 #define VIDEO_MOD_AVAILABLE

--- a/corelib/src/camera/CameraVideo.cpp
+++ b/corelib/src/camera/CameraVideo.cpp
@@ -28,12 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/camera/CameraVideo.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UConversion.h>
-#if CV_MAJOR_VERSION > 3
-#include <opencv2/videoio/videoio_c.h>
-#if CV_MAJOR_VERSION > 4
-#include <opencv2/videoio/legacy/constants_c.h>
-#endif
-#endif
+#include <rtabmap/core/opencv2_compat.h>
 
 namespace rtabmap
 {

--- a/corelib/src/odometry/OdometryDVO.cpp
+++ b/corelib/src/odometry/OdometryDVO.cpp
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/ULogger.h"
 #include "rtabmap/utilite/UTimer.h"
 #include "rtabmap/utilite/UStl.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_DVO
 #include <dvo/dense_tracking.h>

--- a/corelib/src/odometry/OdometryF2M.cpp
+++ b/corelib/src/odometry/OdometryF2M.cpp
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UTimer.h"
 #include "rtabmap/utilite/UMath.h"
 #include "rtabmap/utilite/UConversion.h"
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <rtabmap/core/odometry/OdometryF2M.h>
 #include <pcl/common/io.h>
 

--- a/corelib/src/odometry/OdometryFovis.cpp
+++ b/corelib/src/odometry/OdometryFovis.cpp
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/ULogger.h"
 #include "rtabmap/utilite/UTimer.h"
 #include "rtabmap/utilite/UStl.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_FOVIS
 #include <libfovis/fovis.hpp>

--- a/corelib/src/odometry/OdometryMSCKF.cpp
+++ b/corelib/src/odometry/OdometryMSCKF.cpp
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UTimer.h"
 #include "rtabmap/utilite/UStl.h"
 #include "rtabmap/utilite/UThread.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_MSCKF_VIO
 #include <msckf_vio/image_processor.h>

--- a/corelib/src/odometry/OdometryMono.cpp
+++ b/corelib/src/odometry/OdometryMono.cpp
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UStl.h"
 #include "rtabmap/utilite/UMath.h"
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/video/tracking.hpp>
 #include <pcl/common/centroid.h>
 

--- a/corelib/src/odometry/OdometryORBSLAM2.cpp
+++ b/corelib/src/odometry/OdometryORBSLAM2.cpp
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UStl.h"
 #include "rtabmap/utilite/UDirectory.h"
 #include <pcl/common/transforms.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <rtabmap/core/odometry/OdometryORBSLAM2.h>
 
 #if defined(RTABMAP_ORB_SLAM) and RTABMAP_ORB_SLAM == 2

--- a/corelib/src/odometry/OdometryORBSLAM3.cpp
+++ b/corelib/src/odometry/OdometryORBSLAM3.cpp
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UDirectory.h"
 #include "rtabmap/utilite/UFile.h"
 #include <pcl/common/transforms.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <rtabmap/core/odometry/OdometryORBSLAM3.h>
 
 #if defined(RTABMAP_ORB_SLAM) and RTABMAP_ORB_SLAM == 3

--- a/corelib/src/odometry/OdometryOkvis.cpp
+++ b/corelib/src/odometry/OdometryOkvis.cpp
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UThread.h"
 #include "rtabmap/utilite/UFile.h"
 #include "rtabmap/utilite/UDirectory.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_OKVIS
 #include <iostream>

--- a/corelib/src/odometry/OdometryOpenVINS.cpp
+++ b/corelib/src/odometry/OdometryOpenVINS.cpp
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/ULogger.h"
 #include "rtabmap/utilite/UTimer.h"
 #include <opencv2/core/eigen.hpp>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_OPENVINS
 #include "core/VioManager.h"

--- a/corelib/src/odometry/OdometryVINSFusion.cpp
+++ b/corelib/src/odometry/OdometryVINSFusion.cpp
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UStl.h"
 #include "rtabmap/utilite/UThread.h"
 #include "rtabmap/utilite/UDirectory.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_VINS_FUSION
 #include <estimator/estimator.h>

--- a/corelib/src/odometry/OdometryViso2.cpp
+++ b/corelib/src/odometry/OdometryViso2.cpp
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/ULogger.h"
 #include "rtabmap/utilite/UTimer.h"
 #include "rtabmap/utilite/UStl.h"
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 #ifdef RTABMAP_VISO2
 #include <viso_stereo.h>

--- a/corelib/src/opencv/ORBextractor.cc
+++ b/corelib/src/opencv/ORBextractor.cc
@@ -64,7 +64,7 @@
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <vector>
 #include <algorithm>

--- a/corelib/src/opencv/ORBextractor.h
+++ b/corelib/src/opencv/ORBextractor.h
@@ -31,7 +31,7 @@
 
 #include <vector>
 #include <list>
-#include <opencv2/core/core_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 
 namespace rtabmap

--- a/corelib/src/opencv/Orb.cpp
+++ b/corelib/src/opencv/Orb.cpp
@@ -38,9 +38,9 @@
 #include <rtabmap/utilite/UConversion.h>
 #include <rtabmap/utilite/UStl.h>
 
-#include "opencv2/features2d/features2d.hpp"
+#include "opencv2/features2d.hpp"
 #include "opencv2/imgproc/imgproc.hpp"
-#include "opencv2/imgproc/imgproc_c.h"
+#include <rtabmap/core/opencv2_compat.h>
 #include <algorithm>
 #include <iterator>
 

--- a/corelib/src/opencv/Orb.h
+++ b/corelib/src/opencv/Orb.h
@@ -46,7 +46,7 @@
 #ifndef CORELIB_SRC_OPENCV_ORB_H_
 #define CORELIB_SRC_OPENCV_ORB_H_
 
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 
 namespace rtabmap {
 

--- a/corelib/src/opencv/solvepnp.cpp
+++ b/corelib/src/opencv/solvepnp.cpp
@@ -213,7 +213,11 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 int RANSACUpdateNumIters( double p, double ep, int modelPoints, int maxIters )
 {
     if( modelPoints <= 0 )
+#if CV_MAJOR_VERSION >= 5
+        CV_Error( cv::Error::StsBadArg, "the number of model points should be positive" );
+#else
         CV_Error( 0, "the number of model points should be positive" );
+#endif
 
     p = MAX(p, 0.);
     p = MIN(p, 1.);

--- a/corelib/src/opencv/solvepnp.h
+++ b/corelib/src/opencv/solvepnp.h
@@ -45,9 +45,9 @@
 #define RTABMAP_CORELIB_SRC_OPENCV_SOLVEPNP_H_
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #if CV_MAJOR_VERSION >= 3
-#include <opencv2/calib3d/calib3d_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #endif
 
 namespace cv3 {

--- a/corelib/src/optimizer/OptimizerCeres.cpp
+++ b/corelib/src/optimizer/OptimizerCeres.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UMath.h>
 #include <rtabmap/utilite/UConversion.h>
 #include <rtabmap/utilite/UTimer.h>
+#include <opencv2/calib3d.hpp>
 #include <set>
 
 #include <rtabmap/core/optimizer/OptimizerCeres.h>

--- a/corelib/src/stereo/StereoBM.cpp
+++ b/corelib/src/stereo/StereoBM.cpp
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap/core/stereo/StereoBM.h>
 #include <rtabmap/utilite/ULogger.h>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 namespace rtabmap {
 

--- a/corelib/src/stereo/StereoSGBM.cpp
+++ b/corelib/src/stereo/StereoSGBM.cpp
@@ -27,9 +27,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap/core/stereo/StereoSGBM.h>
 #include <rtabmap/utilite/ULogger.h>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 namespace rtabmap {
 

--- a/corelib/src/util2d.cpp
+++ b/corelib/src/util2d.cpp
@@ -34,11 +34,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/core/util3d_transforms.h>
 #include <rtabmap/core/StereoDense.h>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <opencv2/video/tracking.hpp>
 #include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <map>
 #include <Eigen/Core>
 

--- a/corelib/src/util3d.cpp
+++ b/corelib/src/util3d.cpp
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <pcl/common/transforms.h>
 #include <pcl/common/common.h>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 
 namespace rtabmap
 {

--- a/corelib/src/util3d_correspondences.cpp
+++ b/corelib/src/util3d_correspondences.cpp
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/core/EpipolarGeometry.h>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include <pcl/search/kdtree.h>
 #include <pcl/common/point_tests.h>
 

--- a/corelib/src/util3d_motion_estimation.cpp
+++ b/corelib/src/util3d_motion_estimation.cpp
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/core/util3d_correspondences.h"
 #include "rtabmap/core/util3d.h"
 
+#include <opencv2/calib3d.hpp>
 #include <pcl/common/common.h>
 
 #include "opencv/solvepnp.h"

--- a/corelib/src/util3d_surface.cpp
+++ b/corelib/src/util3d_surface.cpp
@@ -39,8 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UConversion.h"
 #include "rtabmap/utilite/UMath.h"
 #include "rtabmap/utilite/UTimer.h"
-#include <opencv2/core/core_c.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <pcl/search/kdtree.h>
 #include <pcl/surface/gp3.h>
 #include <pcl/features/normal_3d_omp.h>

--- a/guilib/include/rtabmap/gui/DatabaseViewer.h
+++ b/guilib/include/rtabmap/gui/DatabaseViewer.h
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QtCore/QSet>
 #include <QtGui/QImage>
 #include <opencv2/core/core.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <set>
 #include <vector>
 #include <pcl/point_cloud.h>

--- a/guilib/include/rtabmap/gui/ImageView.h
+++ b/guilib/include/rtabmap/gui/ImageView.h
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QtCore/QRectF>
 #include <QtCore/QMultiMap>
 #include <QtCore/QSettings>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <map>
 #include "rtabmap/utilite/UCv2Qt.h"
 #include <rtabmap/core/CameraModel.h>

--- a/guilib/include/rtabmap/gui/KeypointItem.h
+++ b/guilib/include/rtabmap/gui/KeypointItem.h
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QGraphicsTextItem>
 #include <QtGui/QPen>
 #include <QtGui/QBrush>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 
 namespace rtabmap {
 

--- a/guilib/src/CalibrationDialog.cpp
+++ b/guilib/src/CalibrationDialog.cpp
@@ -30,11 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/imgproc_c.h>
-#include <opencv2/calib3d/calib3d.hpp>
-#if CV_MAJOR_VERSION >= 3
-#include <opencv2/calib3d/calib3d_c.h>
-#endif
+#include <rtabmap/core/opencv2_compat.h>
+#include <opencv2/calib3d.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #if CV_MAJOR_VERSION > 2 or (CV_MAJOR_VERSION == 2 and (CV_MINOR_VERSION >4 or (CV_MINOR_VERSION == 4 and CV_SUBMINOR_VERSION >=10)))
 #include <rtabmap/core/stereo/stereoRectifyFisheye.h>

--- a/guilib/src/DatabaseViewer.cpp
+++ b/guilib/src/DatabaseViewer.cpp
@@ -46,8 +46,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/ULogger.h>
 #include <rtabmap/utilite/UDirectory.h>
 #include <rtabmap/utilite/UConversion.h>
-#include <opencv2/core/core_c.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <opencv2/highgui/highgui.hpp>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UFile.h>

--- a/guilib/src/MainWindow.cpp
+++ b/guilib/src/MainWindow.cpp
@@ -70,6 +70,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UPlot.h"
 #include "rtabmap/utilite/UCv2Qt.h"
 
+#include <opencv2/calib3d.hpp>
+
 #include <QtGui/QCloseEvent>
 #include <QtGui/QPixmap>
 #include <QtCore/QDir>

--- a/tools/Camera/main.cpp
+++ b/tools/Camera/main.cpp
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UDirectory.h"
 #include "rtabmap/utilite/UConversion.h"
 #include <opencv2/highgui/highgui.hpp>
-#include <opencv2/highgui/highgui_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <stdio.h>
 
 void showUsage()

--- a/tools/CameraRGBD/main.cpp
+++ b/tools/CameraRGBD/main.cpp
@@ -40,10 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rtabmap/utilite/UEventsManager.h"
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/imgproc/types_c.h>
-#if CV_MAJOR_VERSION >= 3
-#include <opencv2/videoio/videoio_c.h>
-#endif
+#include <rtabmap/core/opencv2_compat.h>
 #include <pcl/visualization/cloud_viewer.h>
 #include <stdio.h>
 #include <signal.h>

--- a/tools/EpipolarGeometry/main.cpp
+++ b/tools/EpipolarGeometry/main.cpp
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/core/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <iostream>
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UDirectory.h>
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/utilite/UMath.h>
-#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/calib3d.hpp>
 #include "rtabmap/core/Features2d.h"
 #include "rtabmap/core/EpipolarGeometry.h"
 #include "rtabmap/core/VWDictionary.h"

--- a/tools/StereoEval/main.cpp
+++ b/tools/StereoEval/main.cpp
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/utilite/UConversion.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UMath.h>
-#include <opencv2/imgproc/types_c.h>
+#include <rtabmap/core/opencv2_compat.h>
 #include <fstream>
 #include <string>
 

--- a/tools/VocabularyComparison/main.cpp
+++ b/tools/VocabularyComparison/main.cpp
@@ -26,12 +26,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <opencv2/core/core.hpp>
-#include <opencv2/core/types_c.h>
-#include <opencv2/highgui/highgui_c.h>
-#include <opencv2/imgproc/imgproc_c.h>
 #include <opencv2/flann/miniflann.hpp>
-#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/features2d.hpp>
 #include <opencv2/nonfree/features2d.hpp>
+#include <rtabmap/core/opencv2_compat.h>
 #include <rtabmap/utilite/ULogger.h>
 #include <rtabmap/utilite/UTimer.h>
 #include <rtabmap/utilite/UConversion.h>


### PR DESCRIPTION
OpenCV 5 split calib3d into calib/geometry/stereo, renamed features2d to features, and removed the legacy 1.x C API (headers and CV_* aliases). Keep the existing OpenCV 2/3/4 code paths untouched and make OpenCV 5 additive:
- CMake requests the new module components only on OpenCV >= 5;
- point the removed nested compat headers at the top-level ones;
- add opencv2_compat.h: on OpenCV >= 5 it maps the CV_* aliases rtabmap uses to their cv:: enums (and pulls the legacy C API headers on OpenCV < 5), so the version-guarded source stays as-is;
- guard CameraOpenNICV's OpenNI-v1 code (backend removed in OpenCV 5);
- add a CvMat compat shim in stereoRectifyFisheye.h for the vendored code.ㅋ

---

Just attempt to add opencv 5 compatibility.

- https://github.com/introlab/rtabmap/issues/1730