### PR TITLE
Fix orphaned loop detection progress dialog

### DIFF
--- a/guilib/src/DatabaseViewer.cpp
+++ b/guilib/src/DatabaseViewer.cpp
@@ -4435,13 +4435,6 @@ void DatabaseViewer::detectMoreLoopClosures()
 
 	std::map<int, Transform> optimizedPoses = graphes_.back();
 
-	rtabmap::ProgressDialog * progressDialog = new rtabmap::ProgressDialog(this);
-	progressDialog->setAttribute(Qt::WA_DeleteOnClose);
-	progressDialog->setMaximumSteps(1);
-	progressDialog->setCancelButtonVisible(true);
-	progressDialog->setMinimumWidth(800);
-	progressDialog->show();
-
 	const ParametersMap & parameters = ui_->parameters_toolbox->getParameters();
 	bool loopCovLimited = Parameters::defaultRGBDLoopCovLimited();
 	Parameters::parse(parameters, Parameters::kRGBDLoopCovLimited(), loopCovLimited);
@@ -4470,6 +4463,13 @@ void DatabaseViewer::detectMoreLoopClosures()
 			tr("Intra and inter session parameters are disabled! Enable one or both. You can also select specific nodes of the current component instead."));
 		return;
 	}
+
+	rtabmap::ProgressDialog * progressDialog = new rtabmap::ProgressDialog(this);
+	progressDialog->setAttribute(Qt::WA_DeleteOnClose);
+	progressDialog->setMaximumSteps(1);
+	progressDialog->setCancelButtonVisible(true);
+	progressDialog->setMinimumWidth(800);
+	progressDialog->show();
 
 	std::shared_ptr<Registration> reg(Registration::create(ui_->parameters_toolbox->getParameters()));
 


### PR DESCRIPTION
## Summary

Fixes #1462.

`DatabaseViewer::detectMoreLoopClosures()` currently constructs and shows its progress dialog before validating the session-selection options. When both intra-session and inter-session detection are disabled and no graph nodes are selected, the function displays the validation warning and returns, leaving the already-visible progress dialog behind.

## Implementation

Move the existing progress-dialog construction block below that validation guard. No dialog settings or loop-closure behavior are changed:

- invalid configurations now return after the warning without creating a progress dialog;
- valid configurations create the same dialog with the same ownership, cancellation, sizing, and completion behavior as before.

I kept this as a pure control-flow fix rather than adding cleanup to the error branch, so the resource is never created when no work can start.

## Validation

- confirmed the issue path on current `master`: progress-dialog construction preceded the invalid-option guard;
- confirmed the updated path evaluates the guard before constructing the dialog;
- verified the relocated seven-line construction block is byte-for-byte unchanged;
- `git diff --check` passes;
- the change is limited to `guilib/src/DatabaseViewer.cpp` (`+7/-7`).

The repository does not currently provide a GUI test target for `DatabaseViewer`; the existing cross-platform CI builds will cover compilation of the relocated code.
