### PR TITLE
Fix PnP reprojection error threshold

### DIFF
--- a/corelib/src/opencv/solvepnp.cpp
+++ b/corelib/src/opencv/solvepnp.cpp
@@ -96,7 +96,7 @@ public:
         float* err = _err.getMat().ptr<float>();
 
         for ( i = 0; i < count; ++i)
-            err[i] = (float)norm( ipoints_ptr[i] - projpoints_ptr[i] );
+            err[i] = (float)norm( Matx21f(ipoints_ptr[i] - projpoints_ptr[i]), NORM_L2SQR );
 
     }
 


### PR DESCRIPTION
PnPRansacCallback::computeError() returns Euclidean pixel distance, while findInliers() compares it against the squared threshold. As a result, Vis/PnPReprojError=2 accepts errors up to 4 pixels instead of 2.

In our indoor localization testing, this allowed weak matches in a repetitive scene to pass PnP, causing approximately 0.3 m pose jumps while the robot was stationary.

The RTAB-Map solver was copied from OpenCV 3.1. OpenCV fixed the same bug in 2016 by using NORM_L2SQR, but that correction never reached the RTAB-Map copy:
https://github.com/opencv/opencv/commit/120531cb464e8568174aecb1e71e8732f30797af

This applies the same one-line correction and fixes the PnP threshold issue reported in #1759.

Tested by compiling corelib/src/opencv/solvepnp.cpp against OpenCV 4.6.
