### PR TITLE
Fixing occupancy grids not 3d spam when subscribing octomap...

### DIFF
--- a/corelib/src/global_map/GridMap.cpp
+++ b/corelib/src/global_map/GridMap.cpp
@@ -237,6 +237,11 @@ void GridMap::assemble(const std::list<std::pair<int, Transform> > & newPoses)
 	if(!cache().empty())
 	{
 		UDEBUG("Updating from cache");
+		int not3DCount = 0;
+		int not3DFirstId = 0;
+		int not3DGroundType = 0;
+		int not3DObstaclesType = 0;
+		int not3DEmptyType = 0;
 		for(std::list<std::pair<int, Transform> >::const_iterator iter = newPoses.begin(); iter!=newPoses.end(); ++iter)
 		{
 			if(uContains(cache(), iter->first))
@@ -245,8 +250,13 @@ void GridMap::assemble(const std::list<std::pair<int, Transform> > & newPoses)
 
 				if(!localGrid.is3D())
 				{
-					UWARN("It seems the local occupancy grids are not 3d, cannot update GridMap! (ground type=%d, obstacles type=%d, empty type=%d)",
-							localGrid.groundCells.type(), localGrid.obstacleCells.type(), localGrid.emptyCells.type());
+					if(++not3DCount == 1)
+					{
+						not3DFirstId = iter->first;
+						not3DGroundType = localGrid.groundCells.type();
+						not3DObstaclesType = localGrid.obstacleCells.type();
+						not3DEmptyType = localGrid.emptyCells.type();
+					}
 					continue;
 				}
 
@@ -338,6 +348,12 @@ void GridMap::assemble(const std::list<std::pair<int, Transform> > & newPoses)
 				}
 				uInsert(occupiedLocalMaps, std::make_pair(iter->first, occupied));
 			}
+		}
+		if(not3DCount)
+		{
+			UWARN("It seems the local occupancy grids are not 3d, cannot update GridMap! "
+					"(%d local grid(s) ignored, first one (id=%d) had ground type=%d, obstacles type=%d, empty type=%d)",
+					not3DCount, not3DFirstId, not3DGroundType, not3DObstaclesType, not3DEmptyType);
 		}
 	}
 

--- a/corelib/src/global_map/OctoMap.cpp
+++ b/corelib/src/global_map/OctoMap.cpp
@@ -479,6 +479,11 @@ void OctoMap::assemble(const std::list<std::pair<int, Transform> > & newPoses)
 	{
 		float rangeMaxSqrd = rangeMax_*rangeMax_;
 		float cellSize = octree_->getResolution();
+		int not3DCount = 0;
+		int not3DFirstId = 0;
+		int not3DGroundType = 0;
+		int not3DObstaclesType = 0;
+		int not3DEmptyType = 0;
 		for(std::list<std::pair<int, Transform> >::const_iterator iter=newPoses.begin(); iter!=newPoses.end(); ++iter)
 		{
 			std::map<int, LocalGrid>::const_iterator localGridIter;
@@ -491,8 +496,13 @@ void OctoMap::assemble(const std::list<std::pair<int, Transform> > & newPoses)
 
 				if(!localGridIter->second.is3D())
 				{
-					UWARN("It seems the local occupancy grids are not 3d, cannot update OctoMap! (ground type=%d, obstacles type=%d, empty type=%d)",
-											ground.type(), obstacles.type(), emptyCells.type());
+					if(++not3DCount == 1)
+					{
+						not3DFirstId = iter->first;
+						not3DGroundType = ground.type();
+						not3DObstaclesType = obstacles.type();
+						not3DEmptyType = emptyCells.type();
+					}
 					continue;
 				}
 
@@ -761,6 +771,12 @@ void OctoMap::assemble(const std::list<std::pair<int, Transform> > & newPoses)
 			{
 				UDEBUG("Did not find %d in cache", iter->first);
 			}
+		}
+		if(not3DCount)
+		{
+			UWARN("It seems the local occupancy grids are not 3d, cannot update OctoMap! "
+					"(%d local grid(s) ignored, first one (id=%d) had ground type=%d, obstacles type=%d, empty type=%d)",
+					not3DCount, not3DFirstId, not3DGroundType, not3DObstaclesType, not3DEmptyType);
 		}
 	}
 


### PR DESCRIPTION
...and grids are 2d

On large maps (>1000 nodes) that didn't create 3D local grids and that someone is subscribing to octomap or grid_map output topics, there was a warning published for every node. If also the UWARN are forwarded as UEvents to rosout, at some point the events queue keep growing, not able to clear up the queue before a bunch of new warnings come by. The effect is that rtabmap node looks memory leaking, though it is just the queue cannot empty fast enough. In this PR, we only publish the warning once, to avoid overflowing UEventsManager's events queue.